### PR TITLE
Fix loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ Files can be stored in S3 if needed by ECS. There are two distinct S3 bucket inp
 
 ### Task Execution File Storage in S3
 
-The inputs `s3_task_execution_bucket` and `s3_task_execution_additional_buckets` are used to control IAM permissions for task execution requiring access to S3. The input `s3_task_execution_bucket` is the name of the main bucket required by ECS task execution, which can be omitted if no S3 permissions are needed. The input `s3_task_execution_additional_buckets` is a list of additional bucket names that may also be needed for task execution. Objects can be uploaded to the bucket named in the input `s3_task_execution_bucket` using the input `s3_task_execution_bucket_objects`, which is a map of bucket paths and file contents. 
+The inputs `s3_task_execution_bucket` and `s3_task_execution_additional_buckets` are used to control IAM permissions for task execution requiring access to S3. The input `s3_task_execution_bucket` is the name of the main bucket required by ECS task execution, which can be omitted if no S3 permissions are needed. The input `s3_task_execution_additional_buckets` is a list of additional bucket names that may also be needed for task execution. Objects can be uploaded to the bucket named in the input `s3_task_execution_bucket` using the input `s3_task_execution_bucket_objects`, which is a map of bucket paths and file contents. Note that if the input `s3_task_execution_bucket_objects` is supplied, `s3_task_execution_bucket` must also be defined.
 
 ### Task File Storage in S3
 
-The input `s3_task_bucket` is used to control IAM permissions for ECS tasks requring access to S3. Objects can be uploaded to the task bucket using the input `s3_task_bucket_objects`: this is a map of bucket paths and file contents.
+The input `s3_task_bucket` is used to control IAM permissions for ECS tasks requring access to S3. Objects can be uploaded to the task bucket using the input `s3_task_bucket_objects`: this is a map of bucket paths and file contents. If the input `s3_task_bucket_objects` is supplied, the input `s3_task_bucket` must also be defined.
 
 ### Sensitive Inputs
 
@@ -90,6 +90,8 @@ Both the `s3_task_execution_bucket_objects` and `s3_task_bucket_objects` inputs 
 The input `datasync_s3_objects_to_efs` can be used to enable AWS DataSync between an S3 bucket and EFS. Note this has no effect if the input `use_efs_persistence` is set to false.
 
 If `datasync_s3_objects_to_efs` and `use_efs_persistence` are both true, DataSync source and target locations will be built. The DataSync source is the S3 bucket named in the input `s3_task_execution_bucket`, the target is the EFS file system created when `use_efs_persistence` is set to `true`. A DataSync task will be created allowing data to be transferred between S3 and EFS. Additionally, security group rules will be created on the security group `aws_security_group.efs` allowing traffic on port 2049 (NFS protocol) to and from the VPC CIDR: this is a requirement for DataSync communication.
+
+Note that if `datasync_s3_objects_to_efs` is set to `true`, the input `s3_task_execution_bucket` must be supplied.
 
 The input `datasync_s3_subdirectory` can be set to sync a specific path in S3. If omitted this will default to the `name_prefix` path: it is assumed that the `s3_task_execution_bucket` will be shared by several services and the `name_prefix` will by default be used to distinguish them.
 

--- a/iam.tf
+++ b/iam.tf
@@ -135,7 +135,7 @@ data "aws_iam_policy_document" "datasync_assume_role" {
 }
 
 data "aws_iam_policy_document" "datasync_permissions" {
-  count = local.use_datasync && local.s3_task_execution_bucket_arn != null ? 1 : 0
+  count = local.use_datasync ? 1 : 0
 
   statement {
     actions = [
@@ -159,7 +159,7 @@ data "aws_iam_policy_document" "datasync_permissions" {
 }
 
 resource "aws_iam_policy" "datasync" {
-  count = local.use_datasync && local.s3_task_execution_bucket_arn != null ? 1 : 0
+  count = local.use_datasync ? 1 : 0
 
   name        = "${local.iam_role_prefix}-datasync"
   path        = "/"
@@ -178,7 +178,7 @@ resource "aws_iam_role" "datasync" {
 }
 
 resource "aws_iam_role_policy_attachment" "datasync" {
-  count = local.use_datasync && local.s3_task_execution_bucket_arn != null ? 1 : 0
+  count = local.use_datasync ? 1 : 0
 
   role       = aws_iam_role.datasync.0.name
   policy_arn = aws_iam_policy.datasync.0.arn

--- a/s3.tf
+++ b/s3.tf
@@ -1,13 +1,13 @@
 # NOTE Terraform will throw an error if a sensitive variable is used directly in for_each
 resource "aws_s3_object" "task_execution" {
-  for_each = var.s3_task_execution_bucket != null ? nonsensitive(toset(keys(var.s3_task_execution_bucket_objects))) : toset([])
+  for_each = nonsensitive(toset(keys(var.s3_task_execution_bucket_objects)))
   bucket   = var.s3_task_execution_bucket
   key      = each.key
   content  = var.s3_task_execution_bucket_objects[each.key]
 }
 
 resource "aws_s3_object" "task" {
-  for_each = var.s3_task_bucket != null ? nonsensitive(toset(keys(var.s3_task_bucket_objects))) : toset([])
+  for_each = nonsensitive(toset(keys(var.s3_task_bucket_objects)))
   bucket   = var.s3_task_bucket
   key      = each.key
   content  = var.s3_task_bucket_objects[each.key]


### PR DESCRIPTION
## Description

Fix errors with loops based on values not known until apply 

## What Changed?

- Amend count condition `local.use_datasync && local.s3_task_execution_bucket_arn != null` to `local.use_datasync` in resources in `iam.tf`
- Amend for_each loop from `var.s3_task_execution_bucket != null ? nonsensitive(toset(keys(var.s3_task_execution_bucket_objects))) : toset([])` to `nonsensitive(toset(keys(var.s3_task_execution_bucket_objects)))` in `s3.tf`
- Add notes about required variables to `README.md`

## Reason For Change

Current code causes issues with `The "count" value depends on resource attributes that cannot be determined until apply` and `var.s3_task_execution_bucket is a string, known only after apply`

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
