### PR TITLE
Add dependency on EFS mount targets in aws_datasync_location_efs resources

### DIFF
--- a/datasync.tf
+++ b/datasync.tf
@@ -24,6 +24,8 @@ resource "aws_datasync_location_efs" "target" {
     subnet_arn          = data.aws_subnet.efs[count.index].arn
     security_group_arns = [aws_security_group.efs.0.arn]
   }
+
+  depends_on = [aws_efs_mount_target.this] # NOTE needs a dependency as the datasync location needs a mount target in each subnet
 }
 
 resource "aws_datasync_task" "s3_to_efs" {


### PR DESCRIPTION
## Description

Add dependency on EFS mount targets in aws_datasync_location_efs resources

## What Changed?

Add dependency argument on `aws_datasync_location_efs.target` resource

## Reason For Change

Without this change AWS can raise an error when the datasync resource is built if there are no mount targets in the specified subnets

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
