### PR TITLE
Fix/dev deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,6 @@ No modules.
 | <a name="input_ecr_repository_force_delete"></a> [ecr\_repository\_force\_delete](#input\_ecr\_repository\_force\_delete) | Whether to delete non-empty ECR repositories | `bool` | `false` | no |
 | <a name="input_ecr_repository_names"></a> [ecr\_repository\_names](#input\_ecr\_repository\_names) | List of names of ECR repositories required by this workload | `list(string)` | `[]` | no |
 | <a name="input_ecs_cluster_arn"></a> [ecs\_cluster\_arn](#input\_ecs\_cluster\_arn) | ARN of the ECS cluster to which this workload should be deployed | `string` | n/a | yes |
-| <a name="input_ecs_cluster_name"></a> [ecs\_cluster\_name](#input\_ecs\_cluster\_name) | Name of the ECS cluster for use by aws\_appautoscaling\_target resource | `string` | n/a | yes |
 | <a name="input_ecs_network_mode"></a> [ecs\_network\_mode](#input\_ecs\_network\_mode) | Networking mode specified in the ECS Task Definition. One of host, bridge, awsvpc | `string` | `"bridge"` | no |
 | <a name="input_ecs_service_container_name"></a> [ecs\_service\_container\_name](#input\_ecs\_service\_container\_name) | Name of container to associated with the load balancer configuration in the ECS service | `string` | n/a | yes |
 | <a name="input_ecs_service_container_port"></a> [ecs\_service\_container\_port](#input\_ecs\_service\_container\_port) | Container port number associated load balancer configuration in the ECS service. This must match a container port in the container definition port mappings | `number` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ No modules.
 | [aws_iam_policy_document.task_execution_role_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.task_role_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_route53_zone.domain](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_subnet.efs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 | [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 | [external_external.route53_a_record](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |

--- a/acm.tf
+++ b/acm.tf
@@ -11,6 +11,11 @@ resource "aws_acm_certificate" "this" {
 
   lifecycle {
     create_before_destroy = true
+
+    precondition {
+      condition     = endswith(local.domain_name, data.aws_route53_zone.domain.name)
+      error_message = "The domain name ${local.domain_name} does not end with Route 53 domain ${data.aws_route53_zone.domain.name}"
+    }
   }
 }
 
@@ -33,5 +38,10 @@ resource "aws_acm_certificate" "us-east-1" {
 
   lifecycle {
     create_before_destroy = true
+
+    precondition {
+      condition     = endswith(local.domain_name, data.aws_route53_zone.domain.name)
+      error_message = "The domain name ${local.domain_name} does not end with Route 53 domain ${data.aws_route53_zone.domain.name}"
+    }
   }
 }

--- a/ecs.tf
+++ b/ecs.tf
@@ -82,7 +82,7 @@ resource "aws_ecs_service" "this" {
 resource "aws_appautoscaling_target" "ecs" {
   max_capacity       = var.ecs_service_max_capacity
   min_capacity       = var.ecs_service_min_capacity
-  resource_id        = "service/${var.ecs_cluster_name}/${aws_ecs_service.this.name}"
+  resource_id        = local.ecs_service_resource_id
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
 }

--- a/iam.tf
+++ b/iam.tf
@@ -74,7 +74,7 @@ resource "aws_iam_role" "task_role" {
 }
 
 resource "aws_iam_policy" "task_policy" {
-  count = data.aws_iam_policy_document.task_role_permissions.statement != null ? 1 : 0
+  count       = data.aws_iam_policy_document.task_role_permissions.statement != null ? 1 : 0
   name        = "${local.iam_role_prefix}-task-policy"
   path        = "/"
   description = "Policy for ${local.iam_role_prefix}-task-role"

--- a/iam.tf
+++ b/iam.tf
@@ -74,6 +74,7 @@ resource "aws_iam_role" "task_role" {
 }
 
 resource "aws_iam_policy" "task_policy" {
+  count = data.aws_iam_policy_document.task_role_permissions.statement != null ? 1 : 0
   name        = "${local.iam_role_prefix}-task-policy"
   path        = "/"
   description = "Policy for ${local.iam_role_prefix}-task-role"
@@ -107,8 +108,10 @@ data "aws_iam_policy_document" "task_role_permissions" {
 }
 
 resource "aws_iam_role_policy_attachment" "task_policy_attachment" {
+  count = data.aws_iam_policy_document.task_role_permissions.statement != null ? 1 : 0
+
   role       = aws_iam_role.task_role.name
-  policy_arn = aws_iam_policy.task_policy.arn
+  policy_arn = aws_iam_policy.task_policy.0.arn
 }
 
 data "aws_iam_policy_document" "datasync_assume_role" {

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,7 @@
 locals {
   ecr_repository_urls                      = var.ecr_repositories_exist ? { for name, repo in data.aws_ecr_repository.existing : name => repo.repository_url } : { for name, repo in aws_ecr_repository.new : name => repo.repository_url }
   ecr_repository_arns                      = var.ecr_repositories_exist ? [for name, repo in data.aws_ecr_repository.existing : repo.arn] : [for name, repo in aws_ecr_repository.new : repo.arn]
+  ecs_service_resource_id                  = split(format(":%s:", var.account_id), aws_ecs_service.this.id)[1]
   s3_task_execution_bucket_arn             = var.s3_task_execution_bucket != null ? format("arn:aws:s3:::%s", var.s3_task_execution_bucket) : null
   s3_task_execution_additional_bucket_arns = [for bucket in var.s3_task_execution_additional_buckets : format("arn:aws:s3:::%s", bucket)]
   s3_task_execution_bucket_arns            = concat(compact([local.s3_task_execution_bucket_arn]), local.s3_task_execution_additional_bucket_arns)

--- a/route53.tf
+++ b/route53.tf
@@ -1,3 +1,7 @@
+data "aws_route53_zone" "domain" {
+  zone_id = var.route53_zone_id
+}
+
 resource "aws_route53_record" "cloudfront_alias" {
   name = aws_acm_certificate.us-east-1.domain_name # NOTE match CloudFront Distribution alias
   type = "A"
@@ -6,7 +10,7 @@ resource "aws_route53_record" "cloudfront_alias" {
     zone_id                = aws_cloudfront_distribution.this.hosted_zone_id
     evaluate_target_health = false
   }
-  zone_id = var.route53_zone_id
+  zone_id = data.aws_route53_zone.domain.zone_id
 }
 
 resource "aws_route53_record" "acm_validation_cname" {
@@ -23,5 +27,5 @@ resource "aws_route53_record" "acm_validation_cname" {
   records         = [each.value.record]
   ttl             = 300
   type            = each.value.type
-  zone_id         = var.route53_zone_id
+  zone_id         = data.aws_route53_zone.domain.zone_id
 }

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -32,6 +32,13 @@ resource "aws_security_group_rule" "asg_ingress_private_access" {
   source_security_group_id = var.ingress_security_group_id
   from_port                = var.alb_target_group_port
   to_port                  = var.alb_target_group_port
+
+  lifecycle {
+    precondition {
+      condition     = var.ingress_security_group_id != null
+      error_message = "Input ingress_security_group_id must not be null if allow_private_access is set to true"
+    }
+  }
 }
 
 # NOTE this may be needed where the security group owned by an external client

--- a/variables.tf
+++ b/variables.tf
@@ -81,11 +81,6 @@ variable "ecr_repository_force_delete" {
   default     = false
 }
 
-variable "ecs_cluster_name" {
-  type        = string
-  description = "Name of the ECS cluster for use by aws_appautoscaling_target resource"
-}
-
 variable "ecs_cluster_arn" {
   type        = string
   description = "ARN of the ECS cluster to which this workload should be deployed"


### PR DESCRIPTION
## Description

Address issues seen building workload module in `dev` environment

BREAKING CHANGE: The input `ecs_cluster_name` has been removed

## What Changed?

- Remove input `ecs_cluster_name`
- Add local variable `ecs_service_resource_id` derived from ECS service ARN
- Use `local.ecs_service_resource_id` in `resource_id` argument of `aws_appautoscaling_target.ecs` resource
- Add conditions to `aws_iam_policy.task_policy` and `aws_iam_role_policy_attachment.task_policy_attachment` resources
- Add data block `data.aws_route53_zone.domain`
- Replace references to `route53_zone_id` input with data block
- Add precondition block to acm resources to validate `domain_name` input variable
- Add precondition block to `aws_security_group_rule.asg_ingress_private_access` to handle error if `ingress_security_group_id` input is null
- Update README.md

## Reason For Change

When first applying the workload build for SOLR in the `dev` environment, several issues were seen. This change addresses some of these:

```
│ Error: creating Application AutoScaling Target (service/CUDLSolr/dev-solr-service): ValidationException: ECS service doesn't exist: service/CUDLSolr/dev-solr-service
│
│   with module.solr.aws_appautoscaling_target.ecs,
│   on ../../terraform-aws-workload-ecs/ecs.tf line 82, in resource "aws_appautoscaling_target" "ecs":
│   82: resource "aws_appautoscaling_target" "ecs" {
│
```
This error was seen because there was no validation around the input `ecs_cluster_name`. This input is not needed as the `resource_id` argument for the `aws_appautoscaling_target` resource can be derived from the ARN of the ECS service.

```
│ Error: creating IAM Policy (dev-solr-workload-task-policy): operation error IAM: CreatePolicy, https response error StatusCode: 400, RequestID: 5709b459-009e-4197-b87a-7599ec5742c7, MalformedPolicyDocument: Syntax errors in policy.
│
│   with module.solr.aws_iam_policy.task_policy,
│   on ../../terraform-aws-workload-ecs/iam.tf line 76, in resource "aws_iam_policy" "task_policy":
│   76: resource "aws_iam_policy" "task_policy" {
│
╵
```
This error was seen because the policy document for the ECS Task IAM role can be empty if no task bucket is supplied and persistence is not required. The solution is to only attach a policy to the task role if the `statement` property of the `data.aws_iam_policy_document.task_role_permissions` is not null

Additionally there is a need for some validation around the domain name, making sure the suffix matches the Route 53 hosted zone. Also, adding a precondition block to the `aws_security_group_rule.asg_ingress_private_access` better handles an error where `allow_private_access` is set to true and `ingress_security_group_id` is null

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
