### PR TITLE
Fix/task iam role conditionals

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,8 @@ No modules.
 | <a name="input_ingress_security_group_id"></a> [ingress\_security\_group\_id](#input\_ingress\_security\_group\_id) | ID of a security group to grant acess to container instances | `string` | `null` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix to add to resource names | `string` | n/a | yes |
 | <a name="input_route53_zone_id"></a> [route53\_zone\_id](#input\_route53\_zone\_id) | ID of the Route 53 Hosted Zone for records | `string` | n/a | yes |
-| <a name="input_s3_task_bucket"></a> [s3\_task\_bucket](#input\_s3\_task\_bucket) | Name of the S3 Bucket for use by ECS tasks on the host (i.e. running containers) | `string` | `null` | no |
 | <a name="input_s3_task_bucket_objects"></a> [s3\_task\_bucket\_objects](#input\_s3\_task\_bucket\_objects) | Map of S3 bucket keys (file names) and file contents for upload to the task bucket | `map(string)` | `{}` | no |
+| <a name="input_s3_task_buckets"></a> [s3\_task\_buckets](#input\_s3\_task\_buckets) | Names of the S3 Buckets for use by ECS tasks on the host (i.e. running containers) | `list(string)` | `[]` | no |
 | <a name="input_s3_task_execution_additional_buckets"></a> [s3\_task\_execution\_additional\_buckets](#input\_s3\_task\_execution\_additional\_buckets) | Names of additional buckets for adding to the task execution IAM role permissions | `list(string)` | `[]` | no |
 | <a name="input_s3_task_execution_bucket"></a> [s3\_task\_execution\_bucket](#input\_s3\_task\_execution\_bucket) | Name of the bucket for storage of static data for services | `string` | `null` | no |
 | <a name="input_s3_task_execution_bucket_objects"></a> [s3\_task\_execution\_bucket\_objects](#input\_s3\_task\_execution\_bucket\_objects) | Map of S3 bucket keys (file names) and file contents for upload to the task execution bucket | `map(string)` | `{}` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -6,6 +6,6 @@ locals {
   s3_task_execution_additional_bucket_arns = [for bucket in var.s3_task_execution_additional_buckets : format("arn:aws:s3:::%s", bucket)]
   s3_task_execution_bucket_arns            = concat(compact([local.s3_task_execution_bucket_arn]), local.s3_task_execution_additional_bucket_arns)
   s3_task_execution_bucket_arns_iam        = distinct(concat(local.s3_task_execution_bucket_arns, [for bucket in local.s3_task_execution_bucket_arns : format("%s/*", bucket)]))
-  s3_task_role_bucket_arn                  = var.s3_task_bucket != null ? format("arn:aws:s3:::%s", var.s3_task_bucket) : null
-  s3_task_role_bucket_arns_iam             = local.s3_task_role_bucket_arn != null ? [local.s3_task_role_bucket_arn, format("%s/*", local.s3_task_role_bucket_arn)] : []
+  s3_task_role_bucket_arns                 = [for bucket in var.s3_task_buckets : format("arn:aws:s3:::%s", bucket)]
+  s3_task_role_bucket_arns_iam             = concat(local.s3_task_role_bucket_arns, [for arn in local.s3_task_role_bucket_arns : format("%s/*", arn)])
 }

--- a/s3.tf
+++ b/s3.tf
@@ -7,8 +7,8 @@ resource "aws_s3_object" "task_execution" {
 }
 
 resource "aws_s3_object" "task" {
-  for_each = nonsensitive(toset(keys(var.s3_task_bucket_objects)))
-  bucket   = var.s3_task_bucket
+  for_each = length(var.s3_task_buckets) > 0 ? nonsensitive(toset(keys(var.s3_task_bucket_objects))) : []
+  bucket   = var.s3_task_buckets[0]
   key      = each.key
   content  = var.s3_task_bucket_objects[each.key]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -197,10 +197,10 @@ variable "s3_task_execution_bucket_objects" {
   sensitive   = true
 }
 
-variable "s3_task_bucket" {
-  type        = string
-  description = "Name of the S3 Bucket for use by ECS tasks on the host (i.e. running containers)"
-  default     = null
+variable "s3_task_buckets" {
+  type        = list(string)
+  description = "Names of the S3 Buckets for use by ECS tasks on the host (i.e. running containers)"
+  default     = []
 }
 
 variable "s3_task_bucket_objects" {


### PR DESCRIPTION
## Description

 Fix error _The "count" value depends on resource attributes that cannot be determined until apply_ on IAM task policy resources

BREAKING CHANGE: input `s3_task_bucket` renamed to `s3_task_buckets`

## What Changed?

- Remove string input `s3_task_bucket` where the literal value must be known at plan stage
- Add list of strings input `s3_task_buckets` where only the length needs to be known
- Update local variables `s3_task_role_bucket_arns` and `s3_task_role_bucket_arns_iam`
- Add condition to `aws_s3_object.task resource`

## Reason For Change

Current code causes error _The "count" value depends on resource attributes that cannot be determined until apply_ as the value of the string `s3_task_bucket` must be known at plan stage

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
