### PR TITLE
Fix/efs subnet ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,13 @@ An output `ecr_repository_urls` shows the URIs indicated by the input `ecr_repos
 
 ## EFS Persistence
 
-The module can optionally create an EFS file system, mount targets and access point, as well as a dedicated Security Group for the EFS mount targets. The input `use_efs_persistence` should be set to `true` if this is desired. An EFS mount target is created for each subnet in the input `vpc_subnet_ids`, allowing EFS to be accessed from inside the subnets specified. A reference to the EFS file system is created in the ECS Task Definition. For each item in the input `ecs_task_def_volumes`, if `use_efs_persistence` is set to `true`, a reference is created between the volume and the EFS file system, effectively mounting the ECS volume on the EFS file system. 
+The module can optionally create an EFS file system, mount targets and access point, as well as a dedicated Security Group for the EFS mount targets. The input `use_efs_persistence` should be set to `true` if this is desired. An EFS mount target is created for each subnet in the input `vpc_subnet_ids`, allowing EFS to be accessed from inside the subnets specified. Note that the list input `vpc_subnet_ids` must have a non-zero length if `use_efs_persistence` is true, as ECS services deployed in a VPC require the mount targets to exist in each subnet used: the mount targets allow the DNS address of the EFS file system to be resolved.
+
+A reference to the EFS file system is created in the ECS Task Definition. If `use_efs_persistence` is set to `true`, a reference is created between the volume and the EFS file system for each item in the input `ecs_task_def_volumes`, effectively mounting the ECS volume on the EFS file system. 
 
 The EFS Access Point is used to modify the permissions on the EFS file system. In testing, this was necessary to enable ECS to mount the file system correctly. The access point defaults to setting the mount to be owned by the root user on the host, with permissions allowing read, write and executable access. Changing the default settings may lead to ECS being unable to modify the permissions on the root directory, or otherwise Docker on the host being able to create files in the file system where the container user is non-root.
+
+Note that services deployed in a VPC that need access to EFS may need a VPC Endpoint for the service `elasticfilesystem` if they don't have a route to the public interface for EFS.
 
 ## S3 File Storage
 

--- a/efs.tf
+++ b/efs.tf
@@ -21,6 +21,13 @@ resource "aws_efs_file_system" "this" {
   tags = {
     Name = "${var.name_prefix}-efs"
   }
+
+  lifecycle {
+    precondition {
+      condition     = length(var.vpc_subnet_ids) > 0
+      error_message = "EFS resources require the vpc_subnet_ids input to be provided."
+    }
+  }
 }
 
 resource "aws_efs_mount_target" "this" {
@@ -29,6 +36,13 @@ resource "aws_efs_mount_target" "this" {
   file_system_id  = aws_efs_file_system.this.0.id
   subnet_id       = data.aws_subnet.efs[count.index].id
   security_groups = [aws_security_group.efs.0.id]
+
+  lifecycle {
+    precondition {
+      condition     = length(var.vpc_subnet_ids) > 0
+      error_message = "EFS resources require the vpc_subnet_ids input to be provided."
+    }
+  }
 }
 
 resource "aws_efs_access_point" "this" {
@@ -54,5 +68,12 @@ resource "aws_efs_access_point" "this" {
 
   tags = {
     Name = "${var.name_prefix}-efs-access-point"
+  }
+
+  lifecycle {
+    precondition {
+      condition     = length(var.vpc_subnet_ids) > 0
+      error_message = "EFS resources require the vpc_subnet_ids input to be provided."
+    }
   }
 }


### PR DESCRIPTION
## Description

Add precondition blocks to EFS resources to present a clear message if the `vpc_subnet_ids` input is not supplied

## What Changed?

- Add lifecycle/precondition blocks in efs.tf
- Update README.md

## Reason For Change

Currently an EFS file system and access point can be built without `vpc_subnet_ids` being supplied. This will lead to an error where the name of the file system cannot be resolved by ECS services deployed in a VPC. To prevent this the mount targets should always be deployed where `use_efs_persistence` is set to true, for which the `vpc_subnet_ids` input is required.

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
