### PR TITLE
Fix/awsvpc network mode

### DIFF
--- a/datasync.tf
+++ b/datasync.tf
@@ -15,13 +15,13 @@ resource "aws_datasync_location_s3" "source" {
 }
 
 resource "aws_datasync_location_efs" "target" {
-  count = local.use_datasync ? length(data.aws_subnet.efs.*.arn) : 0
+  count = local.use_datasync ? length(data.aws_subnet.ecs.*.arn) : 0
 
   efs_file_system_arn = aws_efs_file_system.this.0.arn
   subdirectory        = "/" # NOTE replicated data would normally go in root of file system
 
   ec2_config {
-    subnet_arn          = data.aws_subnet.efs[count.index].arn
+    subnet_arn          = data.aws_subnet.ecs[count.index].arn
     security_group_arns = [aws_security_group.efs.0.arn]
   }
 
@@ -29,7 +29,7 @@ resource "aws_datasync_location_efs" "target" {
 }
 
 resource "aws_datasync_task" "s3_to_efs" {
-  count = local.use_datasync ? length(data.aws_subnet.efs.*.arn) : 0
+  count = local.use_datasync ? length(data.aws_subnet.ecs.*.arn) : 0
 
   name                     = "${var.name_prefix}-s3-to-efs"
   source_location_arn      = aws_datasync_location_s3.source.0.arn

--- a/ecs.tf
+++ b/ecs.tf
@@ -1,3 +1,9 @@
+data "aws_subnet" "ecs" {
+  count = length(var.vpc_subnet_ids)
+
+  id = var.vpc_subnet_ids[count.index]
+}
+
 resource "aws_ecs_task_definition" "this" {
   container_definitions = var.ecs_task_def_container_definitions
   family                = var.name_prefix
@@ -75,6 +81,14 @@ resource "aws_ecs_service" "this" {
       registry_arn   = aws_service_discovery_service.this.0.arn
       container_name = var.ecs_service_container_name
       container_port = var.ecs_network_mode == "awsvpc" ? null : var.ecs_service_container_port
+    }
+  }
+
+  dynamic "network_configuration" {
+    for_each = var.ecs_network_mode == "awsvpc" ? [1] : []
+    content {
+      subnets         = data.aws_subnet.ecs.*.id
+      security_groups = [var.asg_security_group_id]
     }
   }
 }

--- a/ecs.tf
+++ b/ecs.tf
@@ -74,7 +74,7 @@ resource "aws_ecs_service" "this" {
     content {
       registry_arn   = aws_service_discovery_service.this.0.arn
       container_name = var.ecs_service_container_name
-      container_port = var.ecs_service_container_port
+      container_port = var.ecs_network_mode == "awsvpc" ? null : var.ecs_service_container_port
     }
   }
 }

--- a/efs.tf
+++ b/efs.tf
@@ -1,9 +1,3 @@
-data "aws_subnet" "efs" {
-  count = length(var.vpc_subnet_ids)
-
-  id = var.vpc_subnet_ids[count.index]
-}
-
 # NOTE EFS File System must be multi-AZ as we do not know in advance in which AZ the task will be placed
 resource "aws_efs_file_system" "this" {
   count = var.use_efs_persistence ? 1 : 0
@@ -34,7 +28,7 @@ resource "aws_efs_mount_target" "this" {
   count = var.use_efs_persistence ? length(var.vpc_subnet_ids) : 0
 
   file_system_id  = aws_efs_file_system.this.0.id
-  subnet_id       = data.aws_subnet.efs[count.index].id
+  subnet_id       = data.aws_subnet.ecs[count.index].id
   security_groups = [aws_security_group.efs.0.id]
 
   lifecycle {

--- a/loadbalancer.tf
+++ b/loadbalancer.tf
@@ -35,7 +35,7 @@ resource "aws_lb_target_group" "this" {
   }
   port        = var.alb_target_group_port
   protocol    = var.alb_target_group_protocol
-  target_type = "instance"
+  target_type = var.ecs_network_mode == "awsvpc" ? "ip" : "instance"
   vpc_id      = var.vpc_id
 }
 

--- a/loadbalancer.tf
+++ b/loadbalancer.tf
@@ -41,7 +41,7 @@ resource "aws_lb_target_group" "this" {
 
 # Automatically register autoscaling group instances with load balancer
 resource "aws_autoscaling_attachment" "automatic_attachment" {
-  count =  var.ecs_network_mode == "awsvpc" ? 0 : 1 # NOTE autoscaling attachments only support instance targets
+  count = var.ecs_network_mode == "awsvpc" ? 0 : 1 # NOTE autoscaling attachments only support instance targets
 
   autoscaling_group_name = var.asg_name
   lb_target_group_arn    = aws_lb_target_group.this.arn

--- a/loadbalancer.tf
+++ b/loadbalancer.tf
@@ -41,6 +41,8 @@ resource "aws_lb_target_group" "this" {
 
 # Automatically register autoscaling group instances with load balancer
 resource "aws_autoscaling_attachment" "automatic_attachment" {
+  count =  var.ecs_network_mode == "awsvpc" ? 0 : 1 # NOTE autoscaling attachments only support instance targets
+
   autoscaling_group_name = var.asg_name
   lb_target_group_arn    = aws_lb_target_group.this.arn
 }


### PR DESCRIPTION
## Description

Fix issues when deploying services with `awsvpc` network mode

## What Changed?

- Rename data block `data.aws_subnet.efs` to `data.aws_subnet.ecs`
- Move `data.aws_subnet.ecs` to `ecs.tf`
- Add `network_configuration` block to `aws_ecs_task_definition.this` resource
- Add count to `aws_autoscaling_attachment.automatic_attachment` based on `ecs_network_mode` input
- Add conditional to `target_type` property in `aws_lb_target_group.this`

## Reason For Change

Current deployments with `awsvpc` network mode will fail as the network configuration will be incorrect

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
