### PR TITLE
fix(ecs): Set deployment properties of ECS service using inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ The input `datasync_s3_subdirectory` can be set to sync a specific path in S3. I
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.44.0 |
-| <a name="provider_aws.us-east-1"></a> [aws.us-east-1](#provider\_aws.us-east-1) | 5.44.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | 2.3.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.44.0 |
+| <a name="provider_aws.us-east-1"></a> [aws.us-east-1](#provider\_aws.us-east-1) | ~> 5.44.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.3 |
 
 ## Modules
 
@@ -220,6 +220,8 @@ No modules.
 | <a name="input_ecs_network_mode"></a> [ecs\_network\_mode](#input\_ecs\_network\_mode) | Networking mode specified in the ECS Task Definition. One of host, bridge, awsvpc | `string` | `"bridge"` | no |
 | <a name="input_ecs_service_container_name"></a> [ecs\_service\_container\_name](#input\_ecs\_service\_container\_name) | Name of container to associated with the load balancer configuration in the ECS service | `string` | n/a | yes |
 | <a name="input_ecs_service_container_port"></a> [ecs\_service\_container\_port](#input\_ecs\_service\_container\_port) | Container port number associated load balancer configuration in the ECS service. This must match a container port in the container definition port mappings | `number` | n/a | yes |
+| <a name="input_ecs_service_deployment_maximum_percent"></a> [ecs\_service\_deployment\_maximum\_percent](#input\_ecs\_service\_deployment\_maximum\_percent) | Maximum percentage of tasks to allowed to run during a deployment (percentage of desired count) | `number` | `200` | no |
+| <a name="input_ecs_service_deployment_minimum_healthy_percent"></a> [ecs\_service\_deployment\_minimum\_healthy\_percent](#input\_ecs\_service\_deployment\_minimum\_healthy\_percent) | Minimum percentage of tasks to keep running during a deployment (percentage of desired count) | `number` | `100` | no |
 | <a name="input_ecs_service_desired_count"></a> [ecs\_service\_desired\_count](#input\_ecs\_service\_desired\_count) | Sets the Desired Count for the ECS Service | `number` | `1` | no |
 | <a name="input_ecs_service_iam_role"></a> [ecs\_service\_iam\_role](#input\_ecs\_service\_iam\_role) | ARN of an IAM role to call load balancer for non-awsvpc network modes. AWSServiceRoleForECS is suitable, but AWS will generate an error if the value is used and the role already exists in the account | `string` | `null` | no |
 | <a name="input_ecs_service_max_capacity"></a> [ecs\_service\_max\_capacity](#input\_ecs\_service\_max\_capacity) | Sets the Maximum Capacity for the ECS Service | `number` | `2` | no |

--- a/ecs.tf
+++ b/ecs.tf
@@ -58,8 +58,8 @@ resource "aws_ecs_service" "this" {
   cluster                            = var.ecs_cluster_arn
   desired_count                      = var.ecs_service_desired_count
   task_definition                    = aws_ecs_task_definition.this.arn
-  deployment_maximum_percent         = 200
-  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = var.ecs_service_deployment_maximum_percent
+  deployment_minimum_healthy_percent = var.ecs_service_deployment_minimum_healthy_percent
   iam_role                           = var.ecs_network_mode == "awsvpc" ? null : var.ecs_service_iam_role
   scheduling_strategy                = "REPLICA"
   propagate_tags                     = "SERVICE"

--- a/variables.tf
+++ b/variables.tf
@@ -104,6 +104,18 @@ variable "ecs_service_min_capacity" {
   default     = 1
 }
 
+variable "ecs_service_deployment_maximum_percent" {
+  type        = number
+  description = "Maximum percentage of tasks to allowed to run during a deployment (percentage of desired count)"
+  default     = 200
+}
+
+variable "ecs_service_deployment_minimum_healthy_percent" {
+  type        = number
+  description = "Minimum percentage of tasks to keep running during a deployment (percentage of desired count)"
+  default     = 100
+}
+
 variable "ecs_service_container_name" {
   type        = string
   description = "Name of container to associated with the load balancer configuration in the ECS service"


### PR DESCRIPTION
## Description

Allow `deployment_maximum_percent` and `deployment_minimum_healthy_percent` properties of `aws_ecs_service` resource to be overridden using inputs

## What Changed?

- Add inputs ecs_service_deployment_maximum_percent and ecs_service_deployment_minimum_healthy_percent with safe default values allowing the deployment properties of the ECS service to be overridden in non-production environments

## Reason For Change

Allowing the deployment properties of the ECS service to be overridden makes it easier to deploy new versions of a service in non-production environments, and should make the deployment process clearer.

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
