### PR TITLE
Feature/task execution ssm

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ No modules.
 | <a name="input_s3_task_execution_additional_buckets"></a> [s3\_task\_execution\_additional\_buckets](#input\_s3\_task\_execution\_additional\_buckets) | Names of additional buckets for adding to the task execution IAM role permissions | `list(string)` | `[]` | no |
 | <a name="input_s3_task_execution_bucket"></a> [s3\_task\_execution\_bucket](#input\_s3\_task\_execution\_bucket) | Name of the bucket for storage of static data for services | `string` | `null` | no |
 | <a name="input_s3_task_execution_bucket_objects"></a> [s3\_task\_execution\_bucket\_objects](#input\_s3\_task\_execution\_bucket\_objects) | Map of S3 bucket keys (file names) and file contents for upload to the task execution bucket | `map(string)` | `{}` | no |
+| <a name="input_ssm_task_execution_parameter_arns"></a> [ssm\_task\_execution\_parameter\_arns](#input\_ssm\_task\_execution\_parameter\_arns) | Names of SSM parameters for adding to the task execution IAM role permissions | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags for adding to resources | `map(string)` | `{}` | no |
 | <a name="input_update_ingress_security_group"></a> [update\_ingress\_security\_group](#input\_update\_ingress\_security\_group) | Whether to update external security group by creating an egress rule to this service | `bool` | `false` | no |
 | <a name="input_use_efs_persistence"></a> [use\_efs\_persistence](#input\_use\_efs\_persistence) | Whether to use EFS to persist data | `bool` | `false` | no |

--- a/iam.tf
+++ b/iam.tf
@@ -39,17 +39,23 @@ resource "aws_iam_policy" "task_execution_policy" {
 
 data "aws_iam_policy_document" "task_execution_role_permissions" {
   statement {
-    actions   = ["ecr:*"]
-    resources = local.ecr_repository_arns
-  }
-  statement {
     actions   = ["ecr:GetAuthorizationToken"]
     resources = ["*"]
   }
+
   statement {
     actions   = ["logs:CreateLogStream", "logs:PutLogEvents"]
     resources = ["${var.cloudwatch_log_group_arn}:log-stream:*"]
   }
+
+  dynamic "statement" {
+    for_each = length(local.ecr_repository_arns) > 0 ? [1] : []
+    content {
+      actions   = ["ecr:*"]
+      resources = local.ecr_repository_arns
+    }
+  }
+
   dynamic "statement" {
     for_each = length(local.s3_task_execution_bucket_arns_iam) > 0 ? [1] : []
     content {

--- a/iam.tf
+++ b/iam.tf
@@ -57,6 +57,19 @@ data "aws_iam_policy_document" "task_execution_role_permissions" {
       resources = local.s3_task_execution_bucket_arns_iam
     }
   }
+
+  dynamic "statement" {
+    for_each = length(var.ssm_task_execution_parameter_arns) > 0 ? [1] : []
+    content {
+      actions = [
+        "ssm:DescribeParameters",
+        "ssm:GetParameters",
+        "ssm:GetParameter",
+        "ssm:GetParameterHistory"
+      ]
+      resources = var.ssm_task_execution_parameter_arns
+    }
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "task_execution_policy_attachment" {

--- a/variables.tf
+++ b/variables.tf
@@ -401,3 +401,9 @@ variable "datasync_transfer_mode" {
   description = "The default states DataSync copies only data or metadata that is new or different content from the source location to the destination location"
   default     = "CHANGED"
 }
+
+variable "ssm_task_execution_parameter_arns" {
+  type        = list(string)
+  description = "Names of SSM parameters for adding to the task execution IAM role permissions"
+  default     = []
+}


### PR DESCRIPTION
## Description

Add permissions to Task execution role for SSM Parameter Store. Also amend present error with ECR permissions statement in IAM policy if `ecr_repository_names` input is empty

## What Changed?

- Replace static ECR permissions statement in `data.aws_iam_policy_document.task_execution_role_permissions` with dynamic block
- Add new dynamic statement block for SSM permissions

## Reason For Change

ECS deployments may need access to SSM Parameter Store for sensitive values such as database passwords. Additionally, deployments may not require access to ECS, meaning an error will be generated

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
