### PR TITLE
Feature/efs extra

### DIFF
--- a/.commitlintrc.mjs
+++ b/.commitlintrc.mjs
@@ -3,4 +3,5 @@ export default {
   rules: {
     'subject-case': [0, 'always', []],
   },
+  ignores: [(commit) => commit === '^chore\(release\):(.*)'],
 }

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ No modules.
 | [aws_cloudfront_cache_policy.managed_caching_disabled](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_cache_policy) | data source |
 | [aws_cloudfront_origin_request_policy.managed_all_viewer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_origin_request_policy) | data source |
 | [aws_ecr_repository.existing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecr_repository) | data source |
-| [aws_efs_file_system.other](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/efs_file_system) | data source |
+| [aws_efs_file_system.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/efs_file_system) | data source |
 | [aws_iam_policy_document.datasync_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.datasync_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ecs_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -266,6 +266,7 @@ No modules.
 | <a name="input_efs_posix_user_uid"></a> [efs\_posix\_user\_uid](#input\_efs\_posix\_user\_uid) | POSIX user ID used for all file system operations using the EFS access point. Default maps to root user on Amazon Linux | `number` | `0` | no |
 | <a name="input_efs_root_directory_path"></a> [efs\_root\_directory\_path](#input\_efs\_root\_directory\_path) | Root directory for EFS access point | `string` | `"/"` | no |
 | <a name="input_efs_root_directory_permissions"></a> [efs\_root\_directory\_permissions](#input\_efs\_root\_directory\_permissions) | POSIX permissions to apply to the EFS root directory, in the format of an octal number representing the mode bits | `number` | `777` | no |
+| <a name="input_efs_use_existing_filesystem"></a> [efs\_use\_existing\_filesystem](#input\_efs\_use\_existing\_filesystem) | Whether to use an existing EFS file system | `bool` | `false` | no |
 | <a name="input_efs_use_iam_task_role"></a> [efs\_use\_iam\_task\_role](#input\_efs\_use\_iam\_task\_role) | Whether to use Amazon ECS task IAM role when mounting EFS | `bool` | `true` | no |
 | <a name="input_ingress_security_group_id"></a> [ingress\_security\_group\_id](#input\_ingress\_security\_group\_id) | ID of a security group to grant acess to container instances | `string` | `null` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix to add to resource names | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ Note that if `datasync_s3_objects_to_efs` is set to `true`, the input `s3_task_e
 
 The input `datasync_s3_subdirectory` can be set to sync a specific path in S3. If omitted this will default to the `name_prefix` path: it is assumed that the `s3_task_execution_bucket` will be shared by several services and the `name_prefix` will by default be used to distinguish them.
 
-
 ## ECS Task VPC Networking
 
 When `ecs_network_mode` is set to "awsvpc", AWS assigns the task an private IP address inside the VPC. This allows the task to be assigned its own network configuration. This is configured as a dynamic `network_configuration` block on the `aws_ecs_service.this` resource. Subnets must be specified with the `vpc_subnet_ids` input variable. This input is _not_ required when `ecs_network_mode` is set to "bridge" (the default value). When using the `awsvpc` network mode additional security groups for the task can be specified with the `vpc_security_groups_extra` optional input.
@@ -257,6 +256,8 @@ No modules.
 | <a name="input_ecs_task_def_cpu"></a> [ecs\_task\_def\_cpu](#input\_ecs\_task\_def\_cpu) | Number of cpu units used by the task | `number` | `null` | no |
 | <a name="input_ecs_task_def_memory"></a> [ecs\_task\_def\_memory](#input\_ecs\_task\_def\_memory) | Amount (in MiB) of memory used by the task. Note if this is unset, all container definitions must set memory and/or memoryReservation | `number` | `1024` | no |
 | <a name="input_ecs_task_def_volumes"></a> [ecs\_task\_def\_volumes](#input\_ecs\_task\_def\_volumes) | List of volume names to attach to the ECS Task Definition | `list(string)` | `[]` | no |
+| <a name="input_efs_access_point_id"></a> [efs\_access\_point\_id](#input\_efs\_access\_point\_id) | ID of an existing EFS Access Point | `string` | `null` | no |
+| <a name="input_efs_create_file_system"></a> [efs\_create\_file\_system](#input\_efs\_create\_file\_system) | Whether to create an EFS File System to persist data | `bool` | `false` | no |
 | <a name="input_efs_file_system_id"></a> [efs\_file\_system\_id](#input\_efs\_file\_system\_id) | ID of an existing EFS File System | `string` | `null` | no |
 | <a name="input_efs_nfs_mount_port"></a> [efs\_nfs\_mount\_port](#input\_efs\_nfs\_mount\_port) | NFS protocol port for EFS mounts | `number` | `2049` | no |
 | <a name="input_efs_posix_user_gid"></a> [efs\_posix\_user\_gid](#input\_efs\_posix\_user\_gid) | POSIX group ID used for all file system operations using the EFS access point. Default maps to root user on Amazon Linux | `number` | `0` | no |
@@ -276,7 +277,6 @@ No modules.
 | <a name="input_ssm_task_execution_parameter_arns"></a> [ssm\_task\_execution\_parameter\_arns](#input\_ssm\_task\_execution\_parameter\_arns) | Names of SSM parameters for adding to the task execution IAM role permissions | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags for adding to resources | `map(string)` | `{}` | no |
 | <a name="input_update_ingress_security_group"></a> [update\_ingress\_security\_group](#input\_update\_ingress\_security\_group) | Whether to update external security group by creating an egress rule to this service | `bool` | `false` | no |
-| <a name="input_use_efs_persistence"></a> [use\_efs\_persistence](#input\_use\_efs\_persistence) | Whether to use EFS to persist data | `bool` | `false` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the VPC for the deployment | `string` | n/a | yes |
 | <a name="input_vpc_security_groups_extra"></a> [vpc\_security\_groups\_extra](#input\_vpc\_security\_groups\_extra) | Additional VPC Security Groups to add to the service | `list(string)` | `[]` | no |
 | <a name="input_vpc_subnet_ids"></a> [vpc\_subnet\_ids](#input\_vpc\_subnet\_ids) | VPC Subnet IDs to use with EFS Mount Points | `list(string)` | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ No modules.
 | [aws_cloudfront_cache_policy.managed_caching_disabled](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_cache_policy) | data source |
 | [aws_cloudfront_origin_request_policy.managed_all_viewer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_origin_request_policy) | data source |
 | [aws_ecr_repository.existing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecr_repository) | data source |
+| [aws_efs_file_system.other](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/efs_file_system) | data source |
 | [aws_iam_policy_document.datasync_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.datasync_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ecs_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ No modules.
 | [aws_security_group.efs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.alb_egress_to_asg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.asg_egress_nfs_to_efs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.asg_egress_nfs_to_existing_efs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.asg_ingress_from_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.asg_ingress_private_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.efs_egress_nfs_to_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
@@ -187,7 +188,7 @@ No modules.
 | [aws_cloudfront_cache_policy.managed_caching_disabled](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_cache_policy) | data source |
 | [aws_cloudfront_origin_request_policy.managed_all_viewer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_origin_request_policy) | data source |
 | [aws_ecr_repository.existing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecr_repository) | data source |
-| [aws_efs_file_system.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/efs_file_system) | data source |
+| [aws_efs_file_system.other](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/efs_file_system) | data source |
 | [aws_iam_policy_document.datasync_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.datasync_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ecs_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -266,6 +267,7 @@ No modules.
 | <a name="input_efs_posix_user_uid"></a> [efs\_posix\_user\_uid](#input\_efs\_posix\_user\_uid) | POSIX user ID used for all file system operations using the EFS access point. Default maps to root user on Amazon Linux | `number` | `0` | no |
 | <a name="input_efs_root_directory_path"></a> [efs\_root\_directory\_path](#input\_efs\_root\_directory\_path) | Root directory for EFS access point | `string` | `"/"` | no |
 | <a name="input_efs_root_directory_permissions"></a> [efs\_root\_directory\_permissions](#input\_efs\_root\_directory\_permissions) | POSIX permissions to apply to the EFS root directory, in the format of an octal number representing the mode bits | `number` | `777` | no |
+| <a name="input_efs_security_group_id"></a> [efs\_security\_group\_id](#input\_efs\_security\_group\_id) | ID of an existing EFS Security Group to allow access to ASG | `string` | `null` | no |
 | <a name="input_efs_use_existing_filesystem"></a> [efs\_use\_existing\_filesystem](#input\_efs\_use\_existing\_filesystem) | Whether to use an existing EFS file system | `bool` | `false` | no |
 | <a name="input_efs_use_iam_task_role"></a> [efs\_use\_iam\_task\_role](#input\_efs\_use\_iam\_task\_role) | Whether to use Amazon ECS task IAM role when mounting EFS | `bool` | `true` | no |
 | <a name="input_ingress_security_group_id"></a> [ingress\_security\_group\_id](#input\_ingress\_security\_group\_id) | ID of a security group to grant acess to container instances | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ No modules.
 | [aws_ecr_repository.new](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 | [aws_ecs_service.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_task_definition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
+| [aws_efs_access_point.other](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_access_point) | resource |
 | [aws_efs_access_point.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_access_point) | resource |
 | [aws_efs_file_system.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system) | resource |
 | [aws_efs_mount_target.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_mount_target) | resource |
@@ -259,14 +260,14 @@ No modules.
 | <a name="input_ecs_task_def_memory"></a> [ecs\_task\_def\_memory](#input\_ecs\_task\_def\_memory) | Amount (in MiB) of memory used by the task. Note if this is unset, all container definitions must set memory and/or memoryReservation | `number` | `1024` | no |
 | <a name="input_ecs_task_def_volumes"></a> [ecs\_task\_def\_volumes](#input\_ecs\_task\_def\_volumes) | List of volume names to attach to the ECS Task Definition | `list(string)` | `[]` | no |
 | <a name="input_efs_access_point_id"></a> [efs\_access\_point\_id](#input\_efs\_access\_point\_id) | ID of an existing EFS Access Point | `string` | `null` | no |
+| <a name="input_efs_access_point_posix_user_gid"></a> [efs\_access\_point\_posix\_user\_gid](#input\_efs\_access\_point\_posix\_user\_gid) | POSIX group ID used for all file system operations using the EFS access point. Default maps to root user on Amazon Linux | `number` | `0` | no |
+| <a name="input_efs_access_point_posix_user_secondary_gids"></a> [efs\_access\_point\_posix\_user\_secondary\_gids](#input\_efs\_access\_point\_posix\_user\_secondary\_gids) | Secondary POSIX group IDs used for all file system operations using the EFS access point | `list(number)` | `[]` | no |
+| <a name="input_efs_access_point_posix_user_uid"></a> [efs\_access\_point\_posix\_user\_uid](#input\_efs\_access\_point\_posix\_user\_uid) | POSIX user ID used for all file system operations using the EFS access point. Default maps to root user on Amazon Linux | `number` | `0` | no |
+| <a name="input_efs_access_point_root_directory_path"></a> [efs\_access\_point\_root\_directory\_path](#input\_efs\_access\_point\_root\_directory\_path) | Root directory for EFS access point | `string` | `"/"` | no |
+| <a name="input_efs_access_point_root_directory_permissions"></a> [efs\_access\_point\_root\_directory\_permissions](#input\_efs\_access\_point\_root\_directory\_permissions) | POSIX permissions to apply to the EFS root directory, in the format of an octal number representing the mode bits | `number` | `777` | no |
 | <a name="input_efs_create_file_system"></a> [efs\_create\_file\_system](#input\_efs\_create\_file\_system) | Whether to create an EFS File System to persist data | `bool` | `false` | no |
 | <a name="input_efs_file_system_id"></a> [efs\_file\_system\_id](#input\_efs\_file\_system\_id) | ID of an existing EFS File System | `string` | `null` | no |
 | <a name="input_efs_nfs_mount_port"></a> [efs\_nfs\_mount\_port](#input\_efs\_nfs\_mount\_port) | NFS protocol port for EFS mounts | `number` | `2049` | no |
-| <a name="input_efs_posix_user_gid"></a> [efs\_posix\_user\_gid](#input\_efs\_posix\_user\_gid) | POSIX group ID used for all file system operations using the EFS access point. Default maps to root user on Amazon Linux | `number` | `0` | no |
-| <a name="input_efs_posix_user_secondary_gids"></a> [efs\_posix\_user\_secondary\_gids](#input\_efs\_posix\_user\_secondary\_gids) | Secondary POSIX group IDs used for all file system operations using the EFS access point | `list(number)` | `[]` | no |
-| <a name="input_efs_posix_user_uid"></a> [efs\_posix\_user\_uid](#input\_efs\_posix\_user\_uid) | POSIX user ID used for all file system operations using the EFS access point. Default maps to root user on Amazon Linux | `number` | `0` | no |
-| <a name="input_efs_root_directory_path"></a> [efs\_root\_directory\_path](#input\_efs\_root\_directory\_path) | Root directory for EFS access point | `string` | `"/"` | no |
-| <a name="input_efs_root_directory_permissions"></a> [efs\_root\_directory\_permissions](#input\_efs\_root\_directory\_permissions) | POSIX permissions to apply to the EFS root directory, in the format of an octal number representing the mode bits | `number` | `777` | no |
 | <a name="input_efs_security_group_id"></a> [efs\_security\_group\_id](#input\_efs\_security\_group\_id) | ID of an existing EFS Security Group to allow access to ASG | `string` | `null` | no |
 | <a name="input_efs_use_existing_filesystem"></a> [efs\_use\_existing\_filesystem](#input\_efs\_use\_existing\_filesystem) | Whether to use an existing EFS file system | `bool` | `false` | no |
 | <a name="input_efs_use_iam_task_role"></a> [efs\_use\_iam\_task\_role](#input\_efs\_use\_iam\_task\_role) | Whether to use Amazon ECS task IAM role when mounting EFS | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ No modules.
 | <a name="input_ecs_task_def_cpu"></a> [ecs\_task\_def\_cpu](#input\_ecs\_task\_def\_cpu) | Number of cpu units used by the task | `number` | `null` | no |
 | <a name="input_ecs_task_def_memory"></a> [ecs\_task\_def\_memory](#input\_ecs\_task\_def\_memory) | Amount (in MiB) of memory used by the task. Note if this is unset, all container definitions must set memory and/or memoryReservation | `number` | `1024` | no |
 | <a name="input_ecs_task_def_volumes"></a> [ecs\_task\_def\_volumes](#input\_ecs\_task\_def\_volumes) | List of volume names to attach to the ECS Task Definition | `list(string)` | `[]` | no |
+| <a name="input_efs_file_system_id"></a> [efs\_file\_system\_id](#input\_efs\_file\_system\_id) | ID of an existing EFS File System | `string` | `null` | no |
 | <a name="input_efs_nfs_mount_port"></a> [efs\_nfs\_mount\_port](#input\_efs\_nfs\_mount\_port) | NFS protocol port for EFS mounts | `number` | `2049` | no |
 | <a name="input_efs_posix_user_gid"></a> [efs\_posix\_user\_gid](#input\_efs\_posix\_user\_gid) | POSIX group ID used for all file system operations using the EFS access point. Default maps to root user on Amazon Linux | `number` | `0` | no |
 | <a name="input_efs_posix_user_secondary_gids"></a> [efs\_posix\_user\_secondary\_gids](#input\_efs\_posix\_user\_secondary\_gids) | Secondary POSIX group IDs used for all file system operations using the EFS access point | `list(number)` | `[]` | no |

--- a/datasync.tf
+++ b/datasync.tf
@@ -1,5 +1,5 @@
 locals {
-  use_datasync = var.use_efs_persistence && var.datasync_s3_objects_to_efs
+  use_datasync = local.ecs_task_definition_mount_efs && var.datasync_s3_objects_to_efs
 }
 
 data "aws_s3_bucket" "datasync" {

--- a/datasync.tf
+++ b/datasync.tf
@@ -9,7 +9,7 @@ data "aws_s3_bucket" "datasync" {
 }
 
 resource "aws_datasync_location_s3" "source" {
-  count = local.use_datasync ? 1 : 0
+  count = var.datasync_s3_objects_to_efs ? 1 : 0
 
   s3_bucket_arn = data.aws_s3_bucket.datasync.0.arn
   subdirectory  = var.datasync_s3_subdirectory
@@ -17,6 +17,8 @@ resource "aws_datasync_location_s3" "source" {
   s3_config {
     bucket_access_role_arn = aws_iam_role.datasync.0.arn
   }
+
+  depends_on = [aws_efs_mount_target.this]
 }
 
 resource "aws_datasync_location_efs" "target" {

--- a/ecs.tf
+++ b/ecs.tf
@@ -23,7 +23,7 @@ resource "aws_ecs_task_definition" "this" {
       name = join("-", [var.name_prefix, volume.key])
 
       dynamic "efs_volume_configuration" {
-        for_each = var.use_efs_persistence ? [1] : []
+        for_each = local.ecs_task_definition_mount_efs ? [1] : []
 
         content {
           file_system_id     = aws_efs_file_system.this.0.id
@@ -31,7 +31,7 @@ resource "aws_ecs_task_definition" "this" {
           transit_encryption = "ENABLED"
 
           dynamic "authorization_config" {
-            for_each = var.use_efs_persistence && var.efs_use_iam_task_role ? [1] : []
+            for_each = local.ecs_task_definition_mount_efs && var.efs_use_iam_task_role ? [1] : []
             content {
               access_point_id = aws_efs_access_point.this.0.id
               iam             = "ENABLED"

--- a/ecs.tf
+++ b/ecs.tf
@@ -27,7 +27,7 @@ resource "aws_ecs_task_definition" "this" {
 
         content {
           file_system_id     = try(aws_efs_file_system.this.0.id, var.efs_file_system_id)
-          root_directory     = var.efs_root_directory_path # NOTE this is ignored if authorization_config is used
+          root_directory     = var.efs_access_point_root_directory_path # NOTE this is ignored if authorization_config is used
           transit_encryption = "ENABLED"
 
           dynamic "authorization_config" {

--- a/ecs.tf
+++ b/ecs.tf
@@ -26,14 +26,14 @@ resource "aws_ecs_task_definition" "this" {
         for_each = local.ecs_task_definition_mount_efs ? [1] : []
 
         content {
-          file_system_id     = aws_efs_file_system.this.0.id
+          file_system_id     = try(aws_efs_file_system.this.0.id, var.efs_file_system_id)
           root_directory     = var.efs_root_directory_path # NOTE this is ignored if authorization_config is used
           transit_encryption = "ENABLED"
 
           dynamic "authorization_config" {
-            for_each = local.ecs_task_definition_mount_efs && var.efs_use_iam_task_role ? [1] : []
+            for_each = local.ecs_task_definition_use_authorization_config && var.efs_use_iam_task_role ? [1] : []
             content {
-              access_point_id = aws_efs_access_point.this.0.id
+              access_point_id = try(aws_efs_access_point.this.0.id, var.efs_access_point_id)
               iam             = "ENABLED"
             }
           }

--- a/efs.tf
+++ b/efs.tf
@@ -45,18 +45,18 @@ resource "aws_efs_access_point" "this" {
   file_system_id = aws_efs_file_system.this.0.id
 
   posix_user {
-    gid            = var.efs_posix_user_gid
-    uid            = var.efs_posix_user_uid
-    secondary_gids = var.efs_posix_user_secondary_gids
+    gid            = var.efs_access_point_posix_user_uid
+    uid            = var.efs_access_point_posix_user_gid
+    secondary_gids = var.efs_access_point_posix_user_secondary_gids
   }
 
   root_directory {
-    path = var.efs_root_directory_path
+    path = var.efs_access_point_root_directory_path
 
     creation_info {
-      owner_gid   = var.efs_posix_user_gid
-      owner_uid   = var.efs_posix_user_uid
-      permissions = var.efs_root_directory_permissions
+      owner_gid   = var.efs_access_point_posix_user_uid
+      owner_uid   = var.efs_access_point_posix_user_gid
+      permissions = var.efs_access_point_root_directory_permissions
     }
   }
 
@@ -68,6 +68,44 @@ resource "aws_efs_access_point" "this" {
     precondition {
       condition     = length(var.vpc_subnet_ids) > 0
       error_message = "EFS resources require the vpc_subnet_ids input to be provided."
+    }
+  }
+}
+
+resource "aws_efs_access_point" "other" {
+  count = var.efs_use_existing_filesystem ? 1 : 0
+
+  file_system_id = var.efs_file_system_id
+
+  posix_user {
+    gid            = var.efs_access_point_posix_user_uid
+    uid            = var.efs_access_point_posix_user_gid
+    secondary_gids = var.efs_access_point_posix_user_secondary_gids
+  }
+
+  root_directory {
+    path = var.efs_access_point_root_directory_path
+
+    creation_info {
+      owner_gid   = var.efs_access_point_posix_user_uid
+      owner_uid   = var.efs_access_point_posix_user_gid
+      permissions = var.efs_access_point_root_directory_permissions
+    }
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-efs-access-point"
+  }
+
+  lifecycle {
+    precondition {
+      condition     = length(var.vpc_subnet_ids) > 0
+      error_message = "EFS resources require the vpc_subnet_ids input to be provided."
+    }
+
+    precondition {
+      condition     = var.efs_file_system_id != null
+      error_message = "To use an existing filesystem the input efs_file_system_id must be provided."
     }
   }
 }

--- a/efs.tf
+++ b/efs.tf
@@ -1,6 +1,6 @@
 # NOTE EFS File System must be multi-AZ as we do not know in advance in which AZ the task will be placed
 resource "aws_efs_file_system" "this" {
-  count = var.use_efs_persistence ? 1 : 0
+  count = local.efs_create_file_system ? 1 : 0
 
   encrypted = true
 
@@ -25,7 +25,7 @@ resource "aws_efs_file_system" "this" {
 }
 
 resource "aws_efs_mount_target" "this" {
-  count = var.use_efs_persistence ? length(var.vpc_subnet_ids) : 0
+  count = local.efs_create_file_system ? length(var.vpc_subnet_ids) : 0
 
   file_system_id  = aws_efs_file_system.this.0.id
   subnet_id       = data.aws_subnet.ecs[count.index].id
@@ -40,7 +40,7 @@ resource "aws_efs_mount_target" "this" {
 }
 
 resource "aws_efs_access_point" "this" {
-  count = var.use_efs_persistence ? 1 : 0
+  count = local.efs_create_file_system ? 1 : 0
 
   file_system_id = aws_efs_file_system.this.0.id
 

--- a/efs.tf
+++ b/efs.tf
@@ -1,6 +1,6 @@
 # NOTE EFS File System must be multi-AZ as we do not know in advance in which AZ the task will be placed
 resource "aws_efs_file_system" "this" {
-  count = local.efs_create_file_system ? 1 : 0
+  count = var.efs_create_file_system ? 1 : 0
 
   encrypted = true
 
@@ -25,7 +25,7 @@ resource "aws_efs_file_system" "this" {
 }
 
 resource "aws_efs_mount_target" "this" {
-  count = local.efs_create_file_system ? length(var.vpc_subnet_ids) : 0
+  count = var.efs_create_file_system ? length(var.vpc_subnet_ids) : 0
 
   file_system_id  = aws_efs_file_system.this.0.id
   subnet_id       = data.aws_subnet.ecs[count.index].id
@@ -40,7 +40,7 @@ resource "aws_efs_mount_target" "this" {
 }
 
 resource "aws_efs_access_point" "this" {
-  count = local.efs_create_file_system ? 1 : 0
+  count = var.efs_create_file_system ? 1 : 0
 
   file_system_id = aws_efs_file_system.this.0.id
 

--- a/iam.tf
+++ b/iam.tf
@@ -163,7 +163,7 @@ data "aws_iam_policy_document" "datasync_assume_role" {
 }
 
 data "aws_iam_policy_document" "datasync_permissions" {
-  count = local.use_datasync ? 1 : 0
+  count = var.datasync_s3_objects_to_efs ? 1 : 0
 
   statement {
     actions = [
@@ -187,7 +187,7 @@ data "aws_iam_policy_document" "datasync_permissions" {
 }
 
 resource "aws_iam_policy" "datasync" {
-  count = local.use_datasync ? 1 : 0
+  count = var.datasync_s3_objects_to_efs ? 1 : 0
 
   name        = "${local.iam_role_prefix}-datasync"
   path        = "/"
@@ -196,7 +196,7 @@ resource "aws_iam_policy" "datasync" {
 }
 
 resource "aws_iam_role" "datasync" {
-  count = local.use_datasync ? 1 : 0
+  count = var.datasync_s3_objects_to_efs ? 1 : 0
 
   path                 = "/"
   description          = "Assumed by DataSync for ${local.iam_role_prefix}"
@@ -206,7 +206,7 @@ resource "aws_iam_role" "datasync" {
 }
 
 resource "aws_iam_role_policy_attachment" "datasync" {
-  count = local.use_datasync ? 1 : 0
+  count = var.datasync_s3_objects_to_efs ? 1 : 0
 
   role       = aws_iam_role.datasync.0.name
   policy_arn = aws_iam_policy.datasync.0.arn

--- a/iam.tf
+++ b/iam.tf
@@ -22,7 +22,7 @@ data "aws_iam_policy_document" "ecs_assume_role" {
 }
 
 data "aws_efs_file_system" "other" {
-  count = var.efs_file_system_id != null ? 1 : 0
+  count = var.efs_use_existing_filesystem ? 1 : 0
 
   file_system_id = var.efs_file_system_id
 }
@@ -122,7 +122,7 @@ data "aws_iam_policy_document" "task_role_permissions" {
         "elasticfilesystem:ClientWrite",
         "elasticfilesystem:ClientMount"
       ]
-      resources = [try(aws_efs_file_system.this.0.id, data.aws_efs_file_system.other.0.arn)]
+      resources = [try(aws_efs_file_system.this.0.arn, data.aws_efs_file_system.other.0.arn)]
       condition {
         test     = "Bool"
         variable = "elasticfilesystem:AccessedViaMountTarget"

--- a/iam.tf
+++ b/iam.tf
@@ -21,6 +21,12 @@ data "aws_iam_policy_document" "ecs_assume_role" {
   }
 }
 
+data "aws_efs_file_system" "other" {
+  count = var.efs_file_system_id != null ? 1 : 0
+
+  file_system_id = var.efs_file_system_id
+}
+
 resource "aws_iam_role" "task_execution_role" {
   path                 = "/"
   description          = "Executes ECS Tasks for ${local.iam_role_prefix}"
@@ -110,13 +116,13 @@ data "aws_iam_policy_document" "task_role_permissions" {
   }
   # NOTE see https://docs.aws.amazon.com/efs/latest/ug/security_iam_resource-based-policy-examples.html
   dynamic "statement" {
-    for_each = var.use_efs_persistence ? [1] : []
+    for_each = local.ecs_task_definition_mount_efs ? [1] : []
     content {
       actions = [
         "elasticfilesystem:ClientWrite",
         "elasticfilesystem:ClientMount"
       ]
-      resources = [aws_efs_file_system.this.0.arn]
+      resources = [try(aws_efs_file_system.this.0.id, data.aws_efs_file_system.other.0.arn)]
       condition {
         test     = "Bool"
         variable = "elasticfilesystem:AccessedViaMountTarget"

--- a/locals.tf
+++ b/locals.tf
@@ -8,6 +8,6 @@ locals {
   s3_task_execution_bucket_arns_iam            = distinct(concat(local.s3_task_execution_bucket_arns, [for bucket in local.s3_task_execution_bucket_arns : format("%s/*", bucket)]))
   s3_task_role_bucket_arns                     = [for bucket in var.s3_task_buckets : format("arn:aws:s3:::%s", bucket)]
   s3_task_role_bucket_arns_iam                 = concat(local.s3_task_role_bucket_arns, [for arn in local.s3_task_role_bucket_arns : format("%s/*", arn)])
-  ecs_task_definition_mount_efs                = var.efs_create_file_system || var.efs_file_system_id != null ? true : false
+  ecs_task_definition_mount_efs                = var.efs_create_file_system || var.efs_use_existing_filesystem ? true : false
   ecs_task_definition_use_authorization_config = var.efs_create_file_system || (var.efs_file_system_id != null && var.efs_access_point_id != null) ? true : false
 }

--- a/locals.tf
+++ b/locals.tf
@@ -8,4 +8,6 @@ locals {
   s3_task_execution_bucket_arns_iam        = distinct(concat(local.s3_task_execution_bucket_arns, [for bucket in local.s3_task_execution_bucket_arns : format("%s/*", bucket)]))
   s3_task_role_bucket_arns                 = [for bucket in var.s3_task_buckets : format("arn:aws:s3:::%s", bucket)]
   s3_task_role_bucket_arns_iam             = concat(local.s3_task_role_bucket_arns, [for arn in local.s3_task_role_bucket_arns : format("%s/*", arn)])
+  ecs_task_definition_mount_efs            = var.use_efs_persistence || var.efs_file_system_id != null ? true : false
+  efs_create_file_system                   = var.use_efs_persistence && var.efs_file_system_id == null ? true : false
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,13 +1,13 @@
 locals {
-  ecr_repository_urls                      = var.ecr_repositories_exist ? { for name, repo in data.aws_ecr_repository.existing : name => repo.repository_url } : { for name, repo in aws_ecr_repository.new : name => repo.repository_url }
-  ecr_repository_arns                      = var.ecr_repositories_exist ? [for name, repo in data.aws_ecr_repository.existing : repo.arn] : [for name, repo in aws_ecr_repository.new : repo.arn]
-  ecs_service_resource_id                  = split(format(":%s:", var.account_id), aws_ecs_service.this.id)[1]
-  s3_task_execution_bucket_arn             = var.s3_task_execution_bucket != null ? format("arn:aws:s3:::%s", var.s3_task_execution_bucket) : null
-  s3_task_execution_additional_bucket_arns = [for bucket in var.s3_task_execution_additional_buckets : format("arn:aws:s3:::%s", bucket)]
-  s3_task_execution_bucket_arns            = concat(compact([local.s3_task_execution_bucket_arn]), local.s3_task_execution_additional_bucket_arns)
-  s3_task_execution_bucket_arns_iam        = distinct(concat(local.s3_task_execution_bucket_arns, [for bucket in local.s3_task_execution_bucket_arns : format("%s/*", bucket)]))
-  s3_task_role_bucket_arns                 = [for bucket in var.s3_task_buckets : format("arn:aws:s3:::%s", bucket)]
-  s3_task_role_bucket_arns_iam             = concat(local.s3_task_role_bucket_arns, [for arn in local.s3_task_role_bucket_arns : format("%s/*", arn)])
-  ecs_task_definition_mount_efs            = var.use_efs_persistence || var.efs_file_system_id != null ? true : false
-  efs_create_file_system                   = var.use_efs_persistence && var.efs_file_system_id == null ? true : false
+  ecr_repository_urls                          = var.ecr_repositories_exist ? { for name, repo in data.aws_ecr_repository.existing : name => repo.repository_url } : { for name, repo in aws_ecr_repository.new : name => repo.repository_url }
+  ecr_repository_arns                          = var.ecr_repositories_exist ? [for name, repo in data.aws_ecr_repository.existing : repo.arn] : [for name, repo in aws_ecr_repository.new : repo.arn]
+  ecs_service_resource_id                      = split(format(":%s:", var.account_id), aws_ecs_service.this.id)[1]
+  s3_task_execution_bucket_arn                 = var.s3_task_execution_bucket != null ? format("arn:aws:s3:::%s", var.s3_task_execution_bucket) : null
+  s3_task_execution_additional_bucket_arns     = [for bucket in var.s3_task_execution_additional_buckets : format("arn:aws:s3:::%s", bucket)]
+  s3_task_execution_bucket_arns                = concat(compact([local.s3_task_execution_bucket_arn]), local.s3_task_execution_additional_bucket_arns)
+  s3_task_execution_bucket_arns_iam            = distinct(concat(local.s3_task_execution_bucket_arns, [for bucket in local.s3_task_execution_bucket_arns : format("%s/*", bucket)]))
+  s3_task_role_bucket_arns                     = [for bucket in var.s3_task_buckets : format("arn:aws:s3:::%s", bucket)]
+  s3_task_role_bucket_arns_iam                 = concat(local.s3_task_role_bucket_arns, [for arn in local.s3_task_role_bucket_arns : format("%s/*", arn)])
+  ecs_task_definition_mount_efs                = var.efs_create_file_system || var.efs_file_system_id != null ? true : false
+  ecs_task_definition_use_authorization_config = var.efs_create_file_system || (var.efs_file_system_id != null && var.efs_access_point_id != null) ? true : false
 }

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -56,7 +56,7 @@ resource "aws_security_group_rule" "private_access_egress" {
 }
 
 resource "aws_security_group" "efs" {
-  count = local.ecs_task_definition_mount_efs ? 1 : 0
+  count = var.efs_create_file_system ? 1 : 0
 
   name        = "${var.name_prefix}-efs"
   description = "Allows access to EFS mount targets for ${var.name_prefix}"
@@ -68,7 +68,7 @@ resource "aws_security_group" "efs" {
 }
 
 resource "aws_security_group_rule" "efs_ingress_nfs_from_asg" {
-  count = local.ecs_task_definition_mount_efs ? 1 : 0
+  count = var.efs_create_file_system ? 1 : 0
 
   type                     = "ingress"
   protocol                 = "tcp"
@@ -80,7 +80,7 @@ resource "aws_security_group_rule" "efs_ingress_nfs_from_asg" {
 }
 
 resource "aws_security_group_rule" "efs_ingress_nfs_from_vpc" {
-  count = local.ecs_task_definition_mount_efs && var.datasync_s3_objects_to_efs ? 1 : 0
+  count = var.efs_create_file_system && var.datasync_s3_objects_to_efs ? 1 : 0
 
   type              = "ingress"
   protocol          = "tcp"
@@ -93,7 +93,7 @@ resource "aws_security_group_rule" "efs_ingress_nfs_from_vpc" {
 }
 
 resource "aws_security_group_rule" "efs_egress_nfs_to_vpc" {
-  count = local.ecs_task_definition_mount_efs && var.datasync_s3_objects_to_efs ? 1 : 0
+  count = var.efs_create_file_system && var.datasync_s3_objects_to_efs ? 1 : 0
 
   type              = "egress"
   protocol          = "tcp"
@@ -106,7 +106,7 @@ resource "aws_security_group_rule" "efs_egress_nfs_to_vpc" {
 }
 
 resource "aws_security_group_rule" "asg_egress_nfs_to_efs" {
-  count = local.ecs_task_definition_mount_efs ? 1 : 0
+  count = var.efs_create_file_system ? 1 : 0
 
   type                     = "egress"
   protocol                 = "tcp"
@@ -115,4 +115,23 @@ resource "aws_security_group_rule" "asg_egress_nfs_to_efs" {
   source_security_group_id = aws_security_group.efs.0.id
   from_port                = var.efs_nfs_mount_port
   to_port                  = var.efs_nfs_mount_port
+}
+
+resource "aws_security_group_rule" "asg_egress_nfs_to_existing_efs" {
+  count = var.efs_use_existing_filesystem ? 1 : 0
+
+  type                     = "egress"
+  protocol                 = "tcp"
+  description              = "ASG Egress on port ${var.efs_nfs_mount_port} for ${var.name_prefix}"
+  security_group_id        = var.asg_security_group_id
+  source_security_group_id = var.efs_security_group_id
+  from_port                = var.efs_nfs_mount_port
+  to_port                  = var.efs_nfs_mount_port
+
+  lifecycle {
+    precondition {
+      condition     = var.efs_security_group_id != null
+      error_message = "To use an existing filesystem the input efs_security_group_id must be provided."
+    }
+  }
 }

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -56,7 +56,7 @@ resource "aws_security_group_rule" "private_access_egress" {
 }
 
 resource "aws_security_group" "efs" {
-  count = var.use_efs_persistence ? 1 : 0
+  count = local.ecs_task_definition_mount_efs ? 1 : 0
 
   name        = "${var.name_prefix}-efs"
   description = "Allows access to EFS mount targets for ${var.name_prefix}"
@@ -68,7 +68,7 @@ resource "aws_security_group" "efs" {
 }
 
 resource "aws_security_group_rule" "efs_ingress_nfs_from_asg" {
-  count = var.use_efs_persistence ? 1 : 0
+  count = local.ecs_task_definition_mount_efs ? 1 : 0
 
   type                     = "ingress"
   protocol                 = "tcp"
@@ -80,7 +80,7 @@ resource "aws_security_group_rule" "efs_ingress_nfs_from_asg" {
 }
 
 resource "aws_security_group_rule" "efs_ingress_nfs_from_vpc" {
-  count = var.use_efs_persistence && var.datasync_s3_objects_to_efs ? 1 : 0
+  count = local.ecs_task_definition_mount_efs && var.datasync_s3_objects_to_efs ? 1 : 0
 
   type              = "ingress"
   protocol          = "tcp"
@@ -93,7 +93,7 @@ resource "aws_security_group_rule" "efs_ingress_nfs_from_vpc" {
 }
 
 resource "aws_security_group_rule" "efs_egress_nfs_to_vpc" {
-  count = var.use_efs_persistence && var.datasync_s3_objects_to_efs ? 1 : 0
+  count = local.ecs_task_definition_mount_efs && var.datasync_s3_objects_to_efs ? 1 : 0
 
   type              = "egress"
   protocol          = "tcp"
@@ -106,7 +106,7 @@ resource "aws_security_group_rule" "efs_egress_nfs_to_vpc" {
 }
 
 resource "aws_security_group_rule" "asg_egress_nfs_to_efs" {
-  count = var.use_efs_persistence ? 1 : 0
+  count = local.ecs_task_definition_mount_efs ? 1 : 0
 
   type                     = "egress"
   protocol                 = "tcp"

--- a/variables.tf
+++ b/variables.tf
@@ -342,6 +342,12 @@ variable "acm_certificate_validation_timeout" {
   default     = "10m"
 }
 
+variable "efs_file_system_id" {
+  type        = string
+  description = "ID of an existing EFS File System"
+  default     = null
+}
+
 variable "efs_root_directory_path" {
   type        = string
   description = "Root directory for EFS access point"

--- a/variables.tf
+++ b/variables.tf
@@ -348,6 +348,12 @@ variable "efs_file_system_id" {
   default     = null
 }
 
+variable "efs_use_existing_filesystem" {
+  type        = bool
+  description = "Whether to use an existing EFS file system"
+  default     = false
+}
+
 variable "efs_access_point_id" {
   type        = string
   description = "ID of an existing EFS Access Point"

--- a/variables.tf
+++ b/variables.tf
@@ -366,7 +366,7 @@ variable "efs_access_point_id" {
   default     = null
 }
 
-variable "efs_root_directory_path" {
+variable "efs_access_point_root_directory_path" {
   type        = string
   description = "Root directory for EFS access point"
   default     = "/"
@@ -378,25 +378,25 @@ variable "efs_use_iam_task_role" {
   default     = true
 }
 
-variable "efs_root_directory_permissions" {
+variable "efs_access_point_root_directory_permissions" {
   type        = number
   description = "POSIX permissions to apply to the EFS root directory, in the format of an octal number representing the mode bits"
   default     = 777
 }
 
-variable "efs_posix_user_gid" {
+variable "efs_access_point_posix_user_gid" {
   type        = number
   description = "POSIX group ID used for all file system operations using the EFS access point. Default maps to root user on Amazon Linux"
   default     = 0
 }
 
-variable "efs_posix_user_uid" {
+variable "efs_access_point_posix_user_uid" {
   type        = number
   description = "POSIX user ID used for all file system operations using the EFS access point. Default maps to root user on Amazon Linux"
   default     = 0
 }
 
-variable "efs_posix_user_secondary_gids" {
+variable "efs_access_point_posix_user_secondary_gids" {
   type        = list(number)
   description = "Secondary POSIX group IDs used for all file system operations using the EFS access point"
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -25,9 +25,9 @@ variable "allow_private_access" {
   default     = false
 }
 
-variable "use_efs_persistence" {
+variable "efs_create_file_system" {
   type        = bool
-  description = "Whether to use EFS to persist data"
+  description = "Whether to create an EFS File System to persist data"
   default     = false
 }
 
@@ -345,6 +345,12 @@ variable "acm_certificate_validation_timeout" {
 variable "efs_file_system_id" {
   type        = string
   description = "ID of an existing EFS File System"
+  default     = null
+}
+
+variable "efs_access_point_id" {
+  type        = string
+  description = "ID of an existing EFS Access Point"
   default     = null
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -348,6 +348,12 @@ variable "efs_file_system_id" {
   default     = null
 }
 
+variable "efs_security_group_id" {
+  type        = string
+  description = "ID of an existing EFS Security Group to allow access to ASG"
+  default     = null
+}
+
 variable "efs_use_existing_filesystem" {
   type        = bool
   description = "Whether to use an existing EFS file system"


### PR DESCRIPTION
## Description

Allow existing EFS file systems to be accessed by an ECS service

BREAKING CHANGE: Various input variables have been renamed

## What Changed?

- Add input variables `efs_use_existing_filesystem`, `efs_file_system_id`, `efs_security_group_id` and `efs_access_point_id`
- Rename input variable `use_efs_persistence` to `efs_create_filesystem` 
- Rename input variable `efs_root_directory_permissions` to `efs_access_point_root_directory_permissions`
- Rename input variable `efs_posix_user_gid` to `efs_access_point_posix_user_gid`
- Rename input variable `efs_posix_user_uid` to `efs_access_point_posix_user_uid`
- Rename input variable `efs_posix_user_secondary_gids` to `efs_access_point_posix_user_secondary_gids`
- Add local variables `ecs_task_definition_mount_efs` and `ecs_task_definition_use_authorization_config`
- Add resources `aws_security_group_rule. asg_egress_nfs_to_existing_efs` and `aws_efs_access_point.other`
- Add data block `data.aws_efs_file_system.other`
- Update `README.md` 

## Reason For Change

Certain ECS services may need access to an existing file system.

This change means that the existing input variable `use_efs_persistence` will need to change to distinguish two use cases that may need access to EFS: where an existing EFS file system is desired, in which case the input variable `efs_use_existing_filesystem ` can be used, and where a new EFS file system is desired, in which case the input variable `efs_create_filesystem` retains the existing functionality. Along with these input changes various other inputs have been renamed to make their purpose clearer.

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
