### PR TITLE
Allow additional IAM policies to be attached to ECS tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ No modules.
 | [aws_iam_role.task_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.task_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.datasync](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.task_additional_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.task_execution_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.task_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lb_listener_certificate.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_certificate) | resource |
@@ -271,6 +272,7 @@ No modules.
 | <a name="input_efs_security_group_id"></a> [efs\_security\_group\_id](#input\_efs\_security\_group\_id) | ID of an existing EFS Security Group to allow access to ASG | `string` | `null` | no |
 | <a name="input_efs_use_existing_filesystem"></a> [efs\_use\_existing\_filesystem](#input\_efs\_use\_existing\_filesystem) | Whether to use an existing EFS file system | `bool` | `false` | no |
 | <a name="input_efs_use_iam_task_role"></a> [efs\_use\_iam\_task\_role](#input\_efs\_use\_iam\_task\_role) | Whether to use Amazon ECS task IAM role when mounting EFS | `bool` | `true` | no |
+| <a name="input_iam_task_additional_policies"></a> [iam\_task\_additional\_policies](#input\_iam\_task\_additional\_policies) | Map of IAM Policies to add to the ECS task permissions. Values should be Policy ARNs; Keys are descriptive strings | `map(string)` | `{}` | no |
 | <a name="input_ingress_security_group_id"></a> [ingress\_security\_group\_id](#input\_ingress\_security\_group\_id) | ID of a security group to grant acess to container instances | `string` | `null` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix to add to resource names | `string` | n/a | yes |
 | <a name="input_route53_zone_id"></a> [route53\_zone\_id](#input\_route53\_zone\_id) | ID of the Route 53 Hosted Zone for records | `string` | n/a | yes |

--- a/iam.tf
+++ b/iam.tf
@@ -211,3 +211,10 @@ resource "aws_iam_role_policy_attachment" "datasync" {
   role       = aws_iam_role.datasync.0.name
   policy_arn = aws_iam_policy.datasync.0.arn
 }
+
+resource "aws_iam_role_policy_attachment" "task_additional_policy_attachment" {
+  for_each = var.iam_task_additional_policies
+
+  role       = aws_iam_role.task_role.name
+  policy_arn = each.value
+}

--- a/variables.tf
+++ b/variables.tf
@@ -461,3 +461,9 @@ variable "datasync_s3_to_efs_pattern" {
   description = "Pattern to filter DataSync transfer task from S3 to EFS"
   default     = null
 }
+
+variable "iam_task_additional_policies" {
+  type        = map(string)
+  description = "Map of IAM Policies to add to the ECS task permissions. Values should be Policy ARNs; Keys are descriptive strings"
+  default     = {}
+}


### PR DESCRIPTION
## Description

Allow additional IAM policies to be attached to ECS tasks

## What Changed?

- Add aws_iam_role_policy_attachment.task_additional_policy_attachment
- Add new input variable iam_task_additional_policies
- Update README.md

## Reason For Change

ECS tasks may need custom IAM permissions not currently available in this module. Additional policy attachments allow these to be added to tasks

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
