### PR TITLE
Add ability to import an existing certificate to ACM

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,11 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_id"></a> [account\_id](#input\_account\_id) | AWS Account ID used to interpolate ECS Service IAM role ARN | `string` | n/a | yes |
+| <a name="input_acm_certificate_certificate_body"></a> [acm\_certificate\_certificate\_body](#input\_acm\_certificate\_certificate\_body) | Existing certificate's PEM-formatted public key | `string` | `null` | no |
+| <a name="input_acm_certificate_certificate_chain"></a> [acm\_certificate\_certificate\_chain](#input\_acm\_certificate\_certificate\_chain) | Existing certificate's PEM-formatted chain | `string` | `null` | no |
+| <a name="input_acm_certificate_private_key"></a> [acm\_certificate\_private\_key](#input\_acm\_certificate\_private\_key) | Existing certificate's PEM-formatted private key | `string` | `null` | no |
 | <a name="input_acm_certificate_validation_timeout"></a> [acm\_certificate\_validation\_timeout](#input\_acm\_certificate\_validation\_timeout) | Length of time to wait for the public ACM certificate to validate | `string` | `"10m"` | no |
+| <a name="input_acm_create_certificate"></a> [acm\_create\_certificate](#input\_acm\_create\_certificate) | Whether to create a certificate in Amazon Certificate Manager | `bool` | `true` | no |
 | <a name="input_alb_arn"></a> [alb\_arn](#input\_alb\_arn) | ARN of the ALB used by the listener | `string` | n/a | yes |
 | <a name="input_alb_dns_name"></a> [alb\_dns\_name](#input\_alb\_dns\_name) | DNS name for the ALB used by the Cloudfront distribution | `string` | n/a | yes |
 | <a name="input_alb_listener_arn"></a> [alb\_listener\_arn](#input\_alb\_listener\_arn) | The Application Load Balancer Listener ARN to add the forward rule and certificate to | `string` | n/a | yes |

--- a/acm.tf
+++ b/acm.tf
@@ -3,11 +3,12 @@ locals {
 }
 
 resource "aws_acm_certificate" "this" {
-  domain_name       = local.domain_name
-  validation_method = "DNS"
-  subject_alternative_names = [
-    local.domain_name
-  ]
+  domain_name               = var.acm_create_certificate ? local.domain_name : null
+  validation_method         = var.acm_create_certificate ? "DNS" : null
+  private_key               = var.acm_certificate_private_key
+  certificate_body          = var.acm_certificate_certificate_body
+  certificate_chain         = var.acm_certificate_certificate_chain
+  subject_alternative_names = var.acm_create_certificate ? [local.domain_name] : null
 
   lifecycle {
     create_before_destroy = true
@@ -20,6 +21,8 @@ resource "aws_acm_certificate" "this" {
 }
 
 resource "aws_acm_certificate_validation" "this" {
+  count = var.acm_create_certificate ? 1 : 0
+
   certificate_arn         = aws_acm_certificate.this.arn
   validation_record_fqdns = [for record in aws_route53_record.acm_validation_cname : record.fqdn]
 
@@ -29,12 +32,13 @@ resource "aws_acm_certificate_validation" "this" {
 }
 
 resource "aws_acm_certificate" "us-east-1" {
-  provider          = aws.us-east-1
-  domain_name       = local.domain_name
-  validation_method = "DNS"
-  subject_alternative_names = [
-    local.domain_name
-  ]
+  provider                  = aws.us-east-1
+  domain_name               = var.acm_create_certificate ? local.domain_name : null
+  validation_method         = var.acm_create_certificate ? "DNS" : null
+  private_key               = var.acm_certificate_private_key
+  certificate_body          = var.acm_certificate_certificate_body
+  certificate_chain         = var.acm_certificate_certificate_chain
+  subject_alternative_names = var.acm_create_certificate ? [local.domain_name] : null
 
   lifecycle {
     create_before_destroy = true

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -11,14 +11,14 @@ data "aws_cloudfront_origin_request_policy" "managed_all_viewer" {
 resource "aws_cloudfront_distribution" "this" {
   provider = aws.us-east-1
 
-  comment         = "${aws_acm_certificate.us-east-1.domain_name} CloudFront Distribution"
+  comment         = "${local.domain_name} CloudFront Distribution"
   price_class     = "PriceClass_100"
   enabled         = true
   web_acl_id      = var.cloudfront_waf_acl_arn
   http_version    = "http2"
   is_ipv6_enabled = true
   aliases = [
-    aws_acm_certificate.us-east-1.domain_name
+    local.domain_name
   ]
 
   origin {
@@ -33,7 +33,7 @@ resource "aws_cloudfront_distribution" "this" {
       ]
     }
     domain_name = var.alb_dns_name
-    origin_id   = aws_acm_certificate.us-east-1.domain_name
+    origin_id   = local.domain_name
     origin_path = ""
   }
 
@@ -42,7 +42,7 @@ resource "aws_cloudfront_distribution" "this" {
     cached_methods           = var.cloudfront_cached_methods
     compress                 = true
     smooth_streaming         = false
-    target_origin_id         = aws_acm_certificate.us-east-1.domain_name
+    target_origin_id         = local.domain_name
     viewer_protocol_policy   = "redirect-to-https"
     cache_policy_id          = data.aws_cloudfront_cache_policy.managed_caching_disabled.id
     origin_request_policy_id = data.aws_cloudfront_origin_request_policy.managed_all_viewer.id

--- a/route53.tf
+++ b/route53.tf
@@ -14,13 +14,13 @@ resource "aws_route53_record" "cloudfront_alias" {
 }
 
 resource "aws_route53_record" "acm_validation_cname" {
-  for_each = {
+  for_each = var.acm_create_certificate ? {
     for dvo in aws_acm_certificate.this.domain_validation_options : dvo.domain_name => {
       name   = dvo.resource_record_name
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
     }
-  }
+  } : {}
 
   allow_overwrite = true
   name            = each.value.name

--- a/variables.tf
+++ b/variables.tf
@@ -336,6 +336,33 @@ variable "update_ingress_security_group" {
   default     = false
 }
 
+variable "acm_create_certificate" {
+  type        = bool
+  description = "Whether to create a certificate in Amazon Certificate Manager"
+  default     = true
+}
+
+variable "acm_certificate_private_key" {
+  type        = string
+  description = "Existing certificate's PEM-formatted private key"
+  default     = null
+  sensitive   = true
+}
+
+variable "acm_certificate_certificate_body" {
+  type        = string
+  description = "Existing certificate's PEM-formatted public key"
+  default     = null
+  sensitive   = true
+}
+
+variable "acm_certificate_certificate_chain" {
+  type        = string
+  description = "Existing certificate's PEM-formatted chain"
+  default     = null
+  sensitive   = true
+}
+
 variable "acm_certificate_validation_timeout" {
   type        = string
   description = "Length of time to wait for the public ACM certificate to validate"


### PR DESCRIPTION
## Description

Add ability to import an existing certificate to ACM

## What Changed?

- Adapt for_each loop on aws_route53_record.acm_validation_cname using condition
- Make aws_acm_certificate_validation.this resource conditional
- Pass private_key, certificate_body and certificate_chain arguments to aws_acm_certificate resources
- Add input variables acm_create_certificate, acm_certificate_private_key, acm_certificate_certificate_body and acm_certificate_certificate_chain
- Update README.md

## Reason For Change

Using an existing certificate means the Route 53 public hosted zone does not need to be linked to a validated domain in AWS. This means a subdomain and certificates can be managed outside AWS and be used by services rather than requiring domains and certificates to be AWS managed

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
