### PR TITLE
feat(acm): Allow use of existing certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,10 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_id"></a> [account\_id](#input\_account\_id) | AWS Account ID used to interpolate ECS Service IAM role ARN | `string` | n/a | yes |
+| <a name="input_acm_certificate_arn"></a> [acm\_certificate\_arn](#input\_acm\_certificate\_arn) | ARN of an existing certificate in Amazon Certificate Manager | `string` | `null` | no |
+| <a name="input_acm_certificate_arn_us-east-1"></a> [acm\_certificate\_arn\_us-east-1](#input\_acm\_certificate\_arn\_us-east-1) | ARN of an existing certificate in us-east-1 AWS Region of Amazon Certificate Manager. For use by CloudFront Distribution | `string` | `null` | no |
 | <a name="input_acm_certificate_validation_timeout"></a> [acm\_certificate\_validation\_timeout](#input\_acm\_certificate\_validation\_timeout) | Length of time to wait for the public ACM certificate to validate | `string` | `"10m"` | no |
+| <a name="input_acm_create_certificate"></a> [acm\_create\_certificate](#input\_acm\_create\_certificate) | Whether to create a certificate in Amazon Certificate Manager | `bool` | `true` | no |
 | <a name="input_alb_arn"></a> [alb\_arn](#input\_alb\_arn) | ARN of the ALB used by the listener | `string` | n/a | yes |
 | <a name="input_alb_dns_name"></a> [alb\_dns\_name](#input\_alb\_dns\_name) | DNS name for the ALB used by the Cloudfront distribution | `string` | n/a | yes |
 | <a name="input_alb_listener_arn"></a> [alb\_listener\_arn](#input\_alb\_listener\_arn) | The Application Load Balancer Listener ARN to add the forward rule and certificate to | `string` | n/a | yes |

--- a/acm.tf
+++ b/acm.tf
@@ -3,6 +3,8 @@ locals {
 }
 
 resource "aws_acm_certificate" "this" {
+  count = var.acm_create_certificate ? 1 : 0
+
   domain_name       = local.domain_name
   validation_method = "DNS"
   subject_alternative_names = [
@@ -20,7 +22,9 @@ resource "aws_acm_certificate" "this" {
 }
 
 resource "aws_acm_certificate_validation" "this" {
-  certificate_arn         = aws_acm_certificate.this.arn
+  count = var.acm_create_certificate ? 1 : 0
+
+  certificate_arn         = aws_acm_certificate.this.0.arn
   validation_record_fqdns = [for record in aws_route53_record.acm_validation_cname : record.fqdn]
 
   timeouts {
@@ -29,6 +33,8 @@ resource "aws_acm_certificate_validation" "this" {
 }
 
 resource "aws_acm_certificate" "us-east-1" {
+  count = var.acm_create_certificate ? 1 : 0
+
   provider          = aws.us-east-1
   domain_name       = local.domain_name
   validation_method = "DNS"

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -11,14 +11,14 @@ data "aws_cloudfront_origin_request_policy" "managed_all_viewer" {
 resource "aws_cloudfront_distribution" "this" {
   provider = aws.us-east-1
 
-  comment         = "${aws_acm_certificate.us-east-1.domain_name} CloudFront Distribution"
+  comment         = "${local.domain_name} CloudFront Distribution"
   price_class     = "PriceClass_100"
   enabled         = true
   web_acl_id      = var.cloudfront_waf_acl_arn
   http_version    = "http2"
   is_ipv6_enabled = true
   aliases = [
-    aws_acm_certificate.us-east-1.domain_name
+    local.domain_name
   ]
 
   origin {
@@ -33,7 +33,7 @@ resource "aws_cloudfront_distribution" "this" {
       ]
     }
     domain_name = var.alb_dns_name
-    origin_id   = aws_acm_certificate.us-east-1.domain_name
+    origin_id   = local.domain_name
     origin_path = ""
   }
 
@@ -42,14 +42,14 @@ resource "aws_cloudfront_distribution" "this" {
     cached_methods           = var.cloudfront_cached_methods
     compress                 = true
     smooth_streaming         = false
-    target_origin_id         = aws_acm_certificate.us-east-1.domain_name
+    target_origin_id         = local.domain_name
     viewer_protocol_policy   = "redirect-to-https"
     cache_policy_id          = data.aws_cloudfront_cache_policy.managed_caching_disabled.id
     origin_request_policy_id = data.aws_cloudfront_origin_request_policy.managed_all_viewer.id
   }
 
   viewer_certificate {
-    acm_certificate_arn            = aws_acm_certificate.us-east-1.arn
+    acm_certificate_arn            = var.acm_create_certificate ? aws_acm_certificate.us-east-1.0.arn : var.acm_certificate_arn_us-east-1
     cloudfront_default_certificate = false
     minimum_protocol_version       = "TLSv1.2_2021"
     ssl_support_method             = "sni-only"

--- a/loadbalancer.tf
+++ b/loadbalancer.tf
@@ -1,8 +1,6 @@
 resource "aws_lb_listener_certificate" "this" {
   listener_arn    = var.alb_listener_arn
-  certificate_arn = aws_acm_certificate.this.arn
-
-  depends_on = [aws_acm_certificate_validation.this]
+  certificate_arn = var.acm_create_certificate ? aws_acm_certificate_validation.this.0.certificate_arn : var.acm_certificate_arn
 }
 
 resource "aws_lb_listener_rule" "this" {
@@ -16,7 +14,7 @@ resource "aws_lb_listener_rule" "this" {
 
   condition {
     host_header {
-      values = [aws_acm_certificate.this.domain_name]
+      values = [local.domain_name]
     }
   }
 }

--- a/route53.tf
+++ b/route53.tf
@@ -3,7 +3,8 @@ data "aws_route53_zone" "domain" {
 }
 
 resource "aws_route53_record" "cloudfront_alias" {
-  name = aws_acm_certificate.us-east-1.domain_name # NOTE match CloudFront Distribution alias
+  name = local.domain_name
+
   type = "A"
   alias {
     name                   = aws_cloudfront_distribution.this.domain_name
@@ -14,13 +15,13 @@ resource "aws_route53_record" "cloudfront_alias" {
 }
 
 resource "aws_route53_record" "acm_validation_cname" {
-  for_each = {
-    for dvo in aws_acm_certificate.this.domain_validation_options : dvo.domain_name => {
+  for_each = var.acm_create_certificate ? {
+    for dvo in aws_acm_certificate.this.0.domain_validation_options : dvo.domain_name => {
       name   = dvo.resource_record_name
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
     }
-  }
+  } : {}
 
   allow_overwrite = true
   name            = each.value.name

--- a/variables.tf
+++ b/variables.tf
@@ -336,6 +336,24 @@ variable "update_ingress_security_group" {
   default     = false
 }
 
+variable "acm_create_certificate" {
+  type        = bool
+  description = "Whether to create a certificate in Amazon Certificate Manager"
+  default     = true
+}
+
+variable "acm_certificate_arn" {
+  type        = string
+  description = "ARN of an existing certificate in Amazon Certificate Manager"
+  default     = null
+}
+
+variable "acm_certificate_arn_us-east-1" {
+  type        = string
+  description = "ARN of an existing certificate in us-east-1 AWS Region of Amazon Certificate Manager. For use by CloudFront Distribution"
+  default     = null
+}
+
 variable "acm_certificate_validation_timeout" {
   type        = string
   description = "Length of time to wait for the public ACM certificate to validate"


### PR DESCRIPTION
## Description

Allow use of an existing certificate in Amazon Certificate Manager

## What Changed?

- Add input variables `acm_create_certificate`, `acm_certificate_arn` and `acm_certificate_arn_us-east-1`
- Add conditions to `aws_acm_certificate.this`, `aws_acm_certificate.us-east-1` and `aws_acm_certificate_validation.this` resources
- Amend references to `aws_acm_certificate.us-east-1.domain_name` to `local.domain_name` in `aws_cloudfront_distribution.this`
- Update `acm_certificate_arn` argument of `viewer_certificate` block of `aws_cloudfront_distribution.this` using condition
- Assign `local.domain_name` to `name` argument of `aws_route53_record.cloudfront_alias`
- Update `for_each` loop of `aws_route53_record.acm_validation_cname` using condition
- Update `README.md`

## Reason For Change

Currently all deployments generate their own certificate in ACM. This places a limitation that the certificates must validated using DNS records backed by a registered domain. This new approach allows domain registration and certificates to be managed outside AWS

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
