### PR TITLE
Allow additional host headers for listener rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ No modules.
 | <a name="input_alb_target_group_protocol"></a> [alb\_target\_group\_protocol](#input\_alb\_target\_group\_protocol) | Protocol to use for the target group | `string` | `"HTTP"` | no |
 | <a name="input_alb_target_group_slow_start"></a> [alb\_target\_group\_slow\_start](#input\_alb\_target\_group\_slow\_start) | Amount time for targets to warm up before the load balancer sends them a full share of requests | `number` | `0` | no |
 | <a name="input_allow_private_access"></a> [allow\_private\_access](#input\_allow\_private\_access) | Whether to allow private access to the service | `bool` | `false` | no |
+| <a name="input_alternative_domain_names"></a> [alternative\_domain\_names](#input\_alternative\_domain\_names) | List of additional domain names to add to ALB listener rule and CloudFront distribution | `list(string)` | `[]` | no |
 | <a name="input_asg_name"></a> [asg\_name](#input\_asg\_name) | Name of Autoscaling Group for registering with ALB Target Group | `string` | n/a | yes |
 | <a name="input_asg_security_group_id"></a> [asg\_security\_group\_id](#input\_asg\_security\_group\_id) | ID of the ASG Security Group for creating ingress from from ALB | `string` | n/a | yes |
 | <a name="input_cloudfront_allowed_methods"></a> [cloudfront\_allowed\_methods](#input\_cloudfront\_allowed\_methods) | List of methods allowed by the CloudFront Distribution | `list(string)` | <pre>[<br>  "HEAD",<br>  "GET",<br>  "OPTIONS"<br>]</pre> | no |

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -17,9 +17,7 @@ resource "aws_cloudfront_distribution" "this" {
   web_acl_id      = var.cloudfront_waf_acl_arn
   http_version    = "http2"
   is_ipv6_enabled = true
-  aliases = [
-    local.domain_name
-  ]
+  aliases         = concat([local.domain_name], var.alternative_domain_names)
 
   origin {
     custom_origin_config {

--- a/loadbalancer.tf
+++ b/loadbalancer.tf
@@ -14,7 +14,7 @@ resource "aws_lb_listener_rule" "this" {
 
   condition {
     host_header {
-      values = [local.domain_name]
+      values = concat([local.domain_name], var.alternative_domain_names)
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -64,6 +64,12 @@ variable "alb_dns_name" {
   description = "DNS name for the ALB used by the Cloudfront distribution"
 }
 
+variable "alternative_domain_names" {
+  type        = list(string)
+  description = "List of additional domain names to add to ALB listener rule and CloudFront distribution"
+  default     = []
+}
+
 variable "cloudfront_waf_acl_arn" {
   type        = string
   description = "ARN of the WAF Web ACL for use by CloudFront"


### PR DESCRIPTION
## Description

Allow additional domain names

## What Changed?

- Update `host_header` block on `aws_lb_listener_rule.this`
- Update `aliases` argument in `aws_cloudfront_distribution.this`
- Add input variable `alternative_domain_names`
- `README.md`

## Reason For Change

The existing implementation limits does not allow redirects. This change allows downstream DNS records to redirect to the service

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
