### PR TITLE
Remove provider version limits in terraform.tf

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,18 +121,15 @@ The inputs `vpc_subnet_ids` and `vpc_security_groups_extra` are ignored if the `
 
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.44.0 |
-| <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.3 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.44.0 |
-| <a name="provider_aws.us-east-1"></a> [aws.us-east-1](#provider\_aws.us-east-1) | ~> 5.44.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws.us-east-1"></a> [aws.us-east-1](#provider\_aws.us-east-1) | n/a |
+| <a name="provider_external"></a> [external](#provider\_external) | n/a |
 
 ## Modules
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,12 +2,10 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "~> 5.44.0"
       configuration_aliases = [aws.us-east-1]
     }
     external = {
-      source  = "hashicorp/external"
-      version = "~> 2.3.3"
+      source = "hashicorp/external"
     }
   }
 }


### PR DESCRIPTION
## Description

Remove provider version limits in `terraform.tf`

## What Changed?

- Remove provider version limits in `terraform.tf`
- Update `README.md`

## Reason For Change

The version constraints currently in place prevent provider version upgrades in parent modules

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
