### PR TITLE
feat(error_pages): Allow this module to allow error pages to be added…

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -12,3 +12,26 @@ resource "aws_s3_object" "task" {
   key      = each.key
   content  = var.s3_task_bucket_objects[each.key]
 }
+
+resource "aws_s3_bucket" "cloudfront_bucket" {
+  count = var.cloudfront_distribution_create && length(var.cloudfront_custom_error_pages_list) > 0 ? 1 : 0
+
+  bucket        = "${var.name_prefix}-cloudfront-bucket"
+  force_destroy = false
+}
+
+locals {
+  cloudfront_custom_error_pages_map = {
+    for page in var.cloudfront_custom_error_pages_list : page.error_code => page
+  }
+}
+
+resource "aws_s3_object" "error_pages" {
+  for_each     = local.cloudfront_custom_error_pages_map
+  bucket       = aws_s3_bucket.cloudfront_bucket[0].id
+  key          = trim(each.value.path, "/")
+  content      = each.value.content
+  content_type = "text/html"
+
+  depends_on = [aws_s3_bucket.cloudfront_bucket]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -135,6 +135,18 @@ variable "cloudfront_access_logging_bucket" {
   default     = null
 }
 
+variable "cloudfront_custom_error_pages_list" {
+  description = "List of custom error pages for CloudFront.  Note: all paths MUST start with /errors/"
+  type = list(object({
+    error_code    = number
+    content       = string
+    path          = string
+    response_code = number
+    ttl           = number
+  }))
+  default = []
+}
+
 variable "ecr_repository_force_delete" {
   type        = bool
   description = "Whether to delete non-empty ECR repositories"


### PR DESCRIPTION
… into the Cloudfront config

## Description

This functionality will allow a list of error pages (including contents) to be specified through the cloudfront_custom_error_pages_list variable. 

This will take the error file contents, save them to an s3 bucket and then setup the cloudfront implementation to add a new origin and behaviour so that when an error code is returned by the origin, then the matching error page is used. 

An example of use might be: 

  cloudfront_custom_error_pages_list = [
    { error_code = 404, content = file("${path.root}/files/error_pages/404.html"), path = "/errors/404.html", response_code = 404, ttl = 300 },
    { error_code = 403, content = file("${path.root}/files/error_pages/403.html"), path = "/errors/403.html", response_code = 403, ttl = 300 }
  ]

## What Changed?


## Breaking Changes

## Reason For Change

Allow Error pages for AMS

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
