### PR TITLE
Fix logic on output cloudfront_distribution_id

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -59,7 +59,7 @@ output "ecs_service_name" {
 }
 
 output "cloudfront_distribution_id" {
-  value       = var.cloudfront_distribution_create ? aws_cloudfront_distribution.this.0.id : ""
+  value       = var.cloudfront_distribution_create && var.allow_public_access ? aws_cloudfront_distribution.this.0.id : ""
   description = "ID of the CloudFront Distribution"
 }
 


### PR DESCRIPTION
## Description

Fix logic on output `cloudfront_distribution_id`

## What Changed?

Condition on `cloudfront_distribution_id` output updated

## Breaking Changes

None

## Reason For Change

The current logic can cause an error 

```
Error: Invalid index 

The given key does not identify an element in this collection value: the collection has no elements.
```

If the input `cloudfront_distribution_create` is set to `true` (the default value) and the input `allow_public_access` is set to `false`

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
