### PR TITLE
feat(cloudfront): add opt-in VPC origin support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+.idea/

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -26,18 +26,29 @@ resource "aws_cloudfront_distribution" "this" {
   aliases         = concat([local.domain_name], var.alternative_domain_names)
 
   origin {
-    custom_origin_config {
-      http_port                = 80
-      https_port               = 443
-      origin_keepalive_timeout = 5
-      origin_protocol_policy   = "https-only"
-      origin_read_timeout      = var.cloudfront_origin_read_timeout
-      origin_ssl_protocols = [
-        "TLSv1.2"
-      ]
+    dynamic "vpc_origin_config" {
+      for_each = var.cloudfront_vpc_origin_id != null ? [1] : []
+      content {
+        vpc_origin_id            = var.cloudfront_vpc_origin_id
+        origin_keepalive_timeout = 5
+        origin_read_timeout      = var.cloudfront_origin_read_timeout
+      }
     }
+
+    dynamic "custom_origin_config" {
+      for_each = var.cloudfront_vpc_origin_id == null ? [1] : []
+      content {
+        http_port                = 80
+        https_port               = 443
+        origin_keepalive_timeout = 5
+        origin_protocol_policy   = "https-only"
+        origin_read_timeout      = var.cloudfront_origin_read_timeout
+        origin_ssl_protocols     = ["TLSv1.2"]
+      }
+    }
+
     connection_attempts = var.cloudfront_origin_connection_attempts
-    domain_name         = var.alb_dns_name
+    domain_name         = var.cloudfront_vpc_origin_id != null ? local.domain_name : var.alb_dns_name
     origin_id           = local.domain_name
     origin_path         = ""
   }

--- a/variables.tf
+++ b/variables.tf
@@ -67,7 +67,14 @@ variable "alb_arn" {
 
 variable "alb_dns_name" {
   type        = string
-  description = "DNS name for the ALB used by the Cloudfront distribution"
+  description = "DNS name for the ALB used by the Cloudfront distribution. Not required when cloudfront_vpc_origin_id is set."
+  default     = null
+}
+
+variable "cloudfront_vpc_origin_id" {
+  type        = string
+  description = "ID of the CloudFront VPC Origin for the ALB. Required when the ALB is internal (not internet-facing), as CloudFront cannot reach it via a custom origin. When set, vpc_origin_config is used instead of custom_origin_config with alb_dns_name."
+  default     = null
 }
 
 variable "alternative_domain_names" {


### PR DESCRIPTION
## Summary
Adds optional cloudfront_vpc_origin_id variable (default null)
When set, the CloudFront distribution uses vpc_origin_config to route traffic to an internal ALB via a VPC Origin
When not set, falls back to the existing custom_origin_config using alb_dns_name — no change for existing callers

## Why
CloudFront cannot reach an internal (non-internet-facing) ALB via a custom origin. VPC Origin support allows CloudFront to connect directly to an internal ALB without exposing it publicly. The cloudfront_vpc_origin_id is emitted as an output from terraform-aws-architecture-ecs when alb_internal = true.

## Dependencies

Must be merged alongside terraform-aws-architecture-ecs [vpc_origin_and_s3_gateway branch], which adds the alb_internal variable and the cloudfront_vpc_origin_id output that this change depends on.

## Upgrade notes

No breaking changes. Existing callers require no changes. To opt in to VPC Origin routing, pass the cloudfront_vpc_origin_id output from the architecture module into this variable.

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
